### PR TITLE
Workflow Prayer Request Action Enhancements

### DIFF
--- a/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
+++ b/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
@@ -52,6 +52,7 @@ namespace rocks.kfs.Workflow.Action.Prayer
     [WorkflowAttribute( "Last Name", "The workflow attribute to use for the Last Name.", false, "", "", 9, null, new string[] { "Rock.Field.Types.TextFieldType" } )]
     [WorkflowAttribute( "Email", "The workflow attribute to use for the Email.", false, "", "", 10, null, new string[] { "Rock.Field.Types.EmailFieldType", "Rock.Field.Types.TextFieldType" } )]
     [WorkflowAttribute( "Campus", "The workflow attribute to use for the Campus.", false, "", "", 11, null, new string[] { "Rock.Field.Types.CampusFieldType" } )]
+    [WorkflowAttribute( "Prayer Request", "The attribute to store the created prayer request guid.", true, "", "", 12, null, new string[] { "Rock.Field.Types.TextFieldType" } )]
 
     #endregion
 
@@ -268,6 +269,23 @@ namespace rocks.kfs.Workflow.Action.Prayer
             {
                 rockContext.SaveChanges();
             } );
+
+            if ( request.Guid != null )
+            {
+                // get the attribute to store the request guid
+                var prayerRequestAttriuteGuid = GetAttributeValue( action, "PrayerRequest" ).AsGuidOrNull();
+                if ( prayerRequestAttriuteGuid.HasValue )
+                {
+                    var prayerRequestAttribute = AttributeCache.Get( prayerRequestAttriuteGuid.Value, rockContext );
+                    if ( prayerRequestAttribute != null )
+                    {
+                        if ( prayerRequestAttribute.FieldTypeId == FieldTypeCache.Get( Rock.SystemGuid.FieldType.TEXT.AsGuid(), rockContext ).Id )
+                        {
+                            SetWorkflowAttributeValue( action, prayerRequestAttriuteGuid.Value, request.Guid.ToString() );
+                        }
+                    }
+                }
+            }
 
             return true;
         }

--- a/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
+++ b/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
@@ -273,15 +273,15 @@ namespace rocks.kfs.Workflow.Action.Prayer
             if ( request.Guid != null )
             {
                 // get the attribute to store the request guid
-                var prayerRequestAttriuteGuid = GetAttributeValue( action, "PrayerRequest" ).AsGuidOrNull();
-                if ( prayerRequestAttriuteGuid.HasValue )
+                var prayerRequestAttributeGuid = GetAttributeValue( action, "PrayerRequest" ).AsGuidOrNull();
+                if ( prayerRequestAttributeGuid.HasValue )
                 {
-                    var prayerRequestAttribute = AttributeCache.Get( prayerRequestAttriuteGuid.Value, rockContext );
+                    var prayerRequestAttribute = AttributeCache.Get( prayerRequestAttributeGuid.Value, rockContext );
                     if ( prayerRequestAttribute != null )
                     {
                         if ( prayerRequestAttribute.FieldTypeId == FieldTypeCache.Get( Rock.SystemGuid.FieldType.TEXT.AsGuid(), rockContext ).Id )
                         {
-                            SetWorkflowAttributeValue( action, prayerRequestAttriuteGuid.Value, request.Guid.ToString() );
+                            SetWorkflowAttributeValue( action, prayerRequestAttributeGuid.Value, request.Guid.ToString() );
                         }
                     }
                 }

--- a/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
+++ b/rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs
@@ -43,7 +43,7 @@ namespace rocks.kfs.Workflow.Action.Prayer
     [IntegerField( "Expires After (Days)", "Number of days until the request will expire (only applies when auto-approved is enabled).", false, 14, "", 0, "ExpireDays" )]
     [BooleanField( "Approved", "Flag indicating if the request should be marked as approved when submitted.", order: 1 )]
     [WorkflowAttribute( "Request", "The workflow attribute to use for the request.", false, "", "", 2, null, new string[] { "Rock.Field.Types.MemoFieldType", "Rock.Field.Types.TextFieldType" } )]
-    [WorkflowAttribute( "Category", "The workflow attribute to use for the Category.", false, "", "", 3, null, new string[] { "Rock.Field.Types.CategoryFieldType", "Rock.Field.Types.TextFieldType" } )]
+    [WorkflowAttribute( "Category", "The workflow attribute to use for the Category.", false, "", "", 3, null, new string[] { "Rock.Field.Types.CategoryFieldType", "Rock.Field.Types.SelectSingleFieldType", "Rock.Field.Types.TextFieldType" } )]
     [WorkflowAttribute( "Allow Comments", "The workflow attribute to use to indicate if comments are allowed.", false, "", "", 4, null, new string[] { "Rock.Field.Types.BooleanFieldType" } )]
     [WorkflowAttribute( "Is Urgent", "The workflow attribute to use to indicate if the request is urgent.", false, "", "", 5, null, new string[] { "Rock.Field.Types.BooleanFieldType" } )]
     [WorkflowAttribute( "Is Public", "The workflow attribute to use to indicate if the request is public.", false, "", "", 6, null, new string[] { "Rock.Field.Types.BooleanFieldType" } )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

* Added option for single select field type in case needed a custom category list.
* Added option to store the guid of the newly created prayer request in the workflow.

---------

### Requested By

##### Who reported, requested, or paid for the change?

New Hope Church

---------

### Screenshots

##### Does this update or add options to the module UI?

![image](https://user-images.githubusercontent.com/3513589/64021242-7df31800-cb01-11e9-91a2-5c49d8e7bf76.png)
_Prayer Request Setting_

---------

### Change Log

##### What files does it affect?

* `rocks.kfs.Workflow.Action.Prayer/AddPrayerRequest.cs`

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
