### PR TITLE
Added job that creates workflows from Exchange

### DIFF
--- a/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
@@ -87,7 +87,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                     var url = new Uri( dataMap.GetString( "ServerUrl" ) );
                     var maxEmails = dataMap.GetString( "MaxEmails" ).AsInteger();
                     var delete = dataMap.GetString( "DeleteMessages" ).AsBoolean();
-                    var single = dataMap.GetString( "OneWorkflowPerConversation" ).AsBoolean();
+                    var onePer = dataMap.GetString( "OneWorkflowPerConversation" ).AsBoolean();
 
                     Dictionary<string, string> attributeKeyMap = null;
                     var workflowAttributeKeys = dataMap.GetString( "WorkflowAttributes" );
@@ -133,7 +133,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                                     var existingWorkflow = new Workflow();
                                     var createWorkflow = true;
 
-                                    if ( single )
+                                    if ( onePer )
                                     {
                                         var conversationId = message.ConversationId.UniqueId.ToString();
 
@@ -149,13 +149,13 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                                         existingWorkflow = new WorkflowService( rockContext )
                                             .Queryable()
                                             .AsNoTracking()
-                                            .FirstOrDefault( w => w.IsActive && w.ForeignKey.Equals( foreignKey, StringComparison.OrdinalIgnoreCase ) );
+                                            .FirstOrDefault( w => w.IsActive && w.ForeignKey.Equals( foreignKey, StringComparison.Ordinal ) );
 
                                         createWorkflow = existingWorkflow.IsNull();
                                     }
                                     else
                                     {
-                                        var emailId = message.ConversationId.UniqueId.ToString();
+                                        var emailId = message.Id.UniqueId.ToString();
 
                                         if ( emailId.Length > 100 )
                                         {
@@ -238,6 +238,8 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                                         }
 
                                         existingWorkflow.SaveAttributeValues();
+
+                                        messages.Add( string.Format( "{0} workflow was appended.", existingWorkflow.Name ) );
                                     }
 
                                     message.IsRead = true;
@@ -278,6 +280,10 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                 {
                     context.Result = "No valid workflow type found.";
                 }
+            }
+            else
+            {
+                context.Result = "Valid workflow type guid was not set.";
             }
         }
     }

--- a/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
@@ -149,7 +149,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                                         existingWorkflow = new WorkflowService( rockContext )
                                             .Queryable()
                                             .AsNoTracking()
-                                            .FirstOrDefault( w => w.ForeignKey.Equals( foreignKey, StringComparison.OrdinalIgnoreCase ) );
+                                            .FirstOrDefault( w => w.IsActive && w.ForeignKey.Equals( foreignKey, StringComparison.OrdinalIgnoreCase ) );
 
                                         createWorkflow = existingWorkflow.IsNull();
                                     }

--- a/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
@@ -1,0 +1,284 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+using Microsoft.Exchange.WebServices.Data;
+using Quartz;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Security;
+using Rock.Web.Cache;
+
+namespace rocks.kfs.WorkflowFromEWS.Jobs
+{
+    [EncryptedTextField( "Username", "The domain\\username or email address for authentication.", order: 0 )]
+    [EncryptedTextField( "Password", isPassword: true, order: 1 )]
+    [TextField( "Email Address", "The email address for the authenticated user to check.", order: 2 )]
+    [UrlLinkField( "Server Url", "", defaultValue: "https://outlook.office365.com/EWS/Exchange.asmx", order: 3 )]
+    [IntegerField( "Max Emails", "The maximum number of emails to process each time the job runs.", defaultValue: 100, order: 4 )]
+    [BooleanField( "Delete Messages", "Each message will be deleted after it is processed.", false, order: 5 )]
+    [BooleanField( "One Workflow Per Conversation", "If a workflow has already been created for a message in this conversation, additional workflows be not created. For example, replies will not activate new workflows.", false, order: 6 )]
+    [WorkflowTypeField( "Workflow Type", "The workflow type to be initiated for each message.", required: true, order: 8 )]
+    [KeyValueListField( "Workflow Attributes", "Used to match the email properties to the new workflow.", true, keyPrompt: "Attribute Key", valuePrompt: "Email Property", customValues: "DateReceived^Date Received,FromEmail^From Email,FromName^From Name,Subject^Subject,Body^Body", displayValueFirst: true, order: 9 )]
+
+    /// <summary>
+    /// Job to create workflow using Exchange Web Services.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public class StartWorkflow : IJob
+    {
+        /// <summary>
+        /// Empty constructor for job initialization
+        /// <para>
+        /// Jobs require a public empty constructor so that the
+        /// scheduler can instantiate the class whenever it needs.
+        /// </para>
+        /// </summary>
+        public StartWorkflow()
+        {
+        }
+
+        /// <summary>
+        /// Job that will send scheduled group emails.
+        ///
+        /// Called by the <see cref="IScheduler" /> when a
+        /// <see cref="ITrigger" /> fires that is associated with
+        /// the <see cref="IJob" />.
+        /// </summary>
+        public virtual void Execute( IJobExecutionContext context )
+        {
+            var dataMap = context.JobDetail.JobDataMap;
+            var messages = new List<string>();
+            var workflowsStarted = 0;
+            var workflowTypeGuid = dataMap.GetString( "WorkflowType" ).AsGuidOrNull();
+
+            if ( workflowTypeGuid.HasValue )
+            {
+                var workflowType = WorkflowTypeCache.Get( workflowTypeGuid.Value );
+
+                if ( workflowType != null )
+                {
+                    var username = Encryption.DecryptString( dataMap.GetString( "Username" ) );
+                    var password = Encryption.DecryptString( dataMap.GetString( "Password" ) );
+                    var emailAddress = dataMap.GetString( "EmailAddress" );
+                    var url = new Uri( dataMap.GetString( "ServerUrl" ) );
+                    var maxEmails = dataMap.GetString( "MaxEmails" ).AsInteger();
+                    var delete = dataMap.GetString( "DeleteMessages" ).AsBoolean();
+                    var single = dataMap.GetString( "OneWorkflowPerConversation" ).AsBoolean();
+
+                    Dictionary<string, string> attributeKeyMap = null;
+                    var workflowAttributeKeys = dataMap.GetString( "WorkflowAttributes" );
+                    if ( workflowAttributeKeys.IsNotNullOrWhiteSpace() )
+                    {
+                        attributeKeyMap = workflowAttributeKeys.AsDictionaryOrNull();
+                    }
+
+                    attributeKeyMap = attributeKeyMap ?? new Dictionary<string, string>();
+
+                    try
+                    {
+                        using ( var rockContext = new RockContext() )
+                        {
+                            var service = new ExchangeService();
+                            service.Credentials = new WebCredentials( username, password );
+                            service.TraceEnabled = true;
+                            service.TraceFlags = TraceFlags.All;
+                            service.Url = url;
+
+                            var findItemPropertySet = new PropertySet( BasePropertySet.IdOnly );
+                            findItemPropertySet.Add( ItemSchema.DateTimeReceived );
+
+                            var userMailbox = new Mailbox( emailAddress );
+                            var folderId = new FolderId( WellKnownFolderName.Inbox, userMailbox );
+                            var sf = new SearchFilter.SearchFilterCollection( LogicalOperator.And, new SearchFilter.IsEqualTo( EmailMessageSchema.IsRead, false ) );
+                            var view = new ItemView( maxEmails );
+                            view.PropertySet = findItemPropertySet;
+                            view.OrderBy.Add( ItemSchema.DateTimeReceived, SortDirection.Ascending );
+                            var findResults = service.FindItems( folderId, sf, view );
+
+                            if ( findResults.Items.Count > 0 )
+                            {
+                                var getMessagePropertySet = new PropertySet( BasePropertySet.FirstClassProperties );
+                                //getMessagePropertySet.Add( ItemSchema.Attachments ); // for future
+
+                                foreach ( var item in findResults )
+                                {
+                                    var message = EmailMessage.Bind( service, item.Id, getMessagePropertySet );
+                                    message.Load();
+
+                                    var foreignKey = string.Empty;
+                                    var existingWorkflow = new Workflow();
+                                    var createWorkflow = true;
+
+                                    if ( single )
+                                    {
+                                        var conversationId = message.ConversationId.UniqueId.ToString();
+
+                                        if ( conversationId.Length > 100 )
+                                        {
+                                            foreignKey = conversationId.Substring( conversationId.Length - 100, 100 );
+                                        }
+                                        else
+                                        {
+                                            foreignKey = conversationId;
+                                        }
+
+                                        existingWorkflow = new WorkflowService( rockContext )
+                                            .Queryable()
+                                            .AsNoTracking()
+                                            .FirstOrDefault( w => w.ForeignKey.Equals( foreignKey, StringComparison.OrdinalIgnoreCase ) );
+
+                                        createWorkflow = existingWorkflow.IsNull();
+                                    }
+                                    else
+                                    {
+                                        var emailId = message.ConversationId.UniqueId.ToString();
+
+                                        if ( emailId.Length > 100 )
+                                        {
+                                            foreignKey = emailId.Substring( emailId.Length - 100, 100 );
+                                        }
+                                        else
+                                        {
+                                            foreignKey = emailId;
+                                        }
+                                    }
+
+                                    if ( createWorkflow )
+                                    {
+                                        var workflow = Rock.Model.Workflow.Activate( workflowType, string.Format( "{0} <{1}> [{2}]", message.From.Name.ToStringSafe(), message.From.Address.ToStringSafe(), message.DateTimeReceived.ToShortDateTimeString() ) );
+                                        workflow.ForeignKey = foreignKey;
+
+                                        workflow.LoadAttributes( rockContext );
+
+                                        foreach ( var keyPair in attributeKeyMap )
+                                        {
+                                            var value = string.Empty;
+
+                                            switch ( keyPair.Value )
+                                            {
+                                                case "DateReceived":
+                                                    value = message.DateTimeReceived.ToString( "o", CultureInfo.CreateSpecificCulture( "en-US" ) );
+                                                    break;
+                                                case "FromEmail":
+                                                    value = message.From.Address.ToStringSafe();
+                                                    break;
+                                                case "FromName":
+                                                    value = message.From.Name.ToStringSafe();
+                                                    break;
+                                                case "Subject":
+                                                    value = message.Subject.ToStringSafe();
+                                                    break;
+                                                case "Body":
+                                                    value = message.Body.Text;
+                                                    break;
+                                                default:
+                                                    break;
+                                            }
+
+                                            if ( workflow.Attributes.ContainsKey( keyPair.Key ) )
+                                            {
+                                                workflow.SetAttributeValue( keyPair.Key, value );
+                                            }
+                                            else
+                                            {
+                                                messages.Add( string.Format( "'{0}' is not an attribute key in the activated workflow: '{1}'", keyPair.Key, workflow.Name ) );
+                                            }
+                                        }
+
+                                        List<string> workflowErrorMessages = new List<string>();
+                                        new Rock.Model.WorkflowService( rockContext ).Process( workflow, out workflowErrorMessages );
+                                        messages.AddRange( workflowErrorMessages );
+                                        workflowsStarted++;
+                                    }
+                                    else if ( existingWorkflow?.Id > 0 )
+                                    {
+                                        existingWorkflow.LoadAttributes();
+
+                                        foreach ( var keyPair in attributeKeyMap )
+                                        {
+                                            if ( keyPair.Value.Contains( "Body" ) )
+                                            {
+                                                var newValue = message.Body.Text;
+
+                                                if ( existingWorkflow.Attributes.ContainsKey( keyPair.Key ) )
+                                                {
+                                                    var existingValue = existingWorkflow.GetAttributeValue( keyPair.Key );
+                                                    var value = string.Format( "{0}{1}{2}", existingValue, Environment.NewLine, newValue );
+                                                    existingWorkflow.SetAttributeValue( keyPair.Key, value );
+                                                }
+                                                else
+                                                {
+                                                    messages.Add( string.Format( "'{0}' is not an attribute key in the activated workflow: '{1}'", keyPair.Key, existingWorkflow.Name ) );
+                                                }
+                                            }
+                                        }
+
+                                        existingWorkflow.SaveAttributeValues();
+                                    }
+
+                                    message.IsRead = true;
+                                    message.Update( ConflictResolutionMode.AlwaysOverwrite, true );
+
+                                    if ( delete )
+                                    {
+                                        message.Delete( DeleteMode.MoveToDeletedItems );
+                                    }
+                                }
+                            }
+
+                            if ( workflowsStarted > 0 )
+                            {
+                                messages.Add( string.Format( "Started {0} {1}", workflowsStarted, "workflow".PluralizeIf( workflowsStarted > 1 ) ) );
+                            }
+                            else
+                            {
+                                messages.Add( "No workflows started" );
+                            }
+
+                            var results = new StringBuilder();
+                            foreach ( var message in messages )
+                            {
+                                results.AppendLine( message );
+                            }
+                            context.Result = results.ToString();
+                        }
+                    }
+                    catch ( System.Exception ex )
+                    {
+                        var context2 = HttpContext.Current;
+                        ExceptionLogService.LogException( ex, context2 );
+                        throw;
+                    }
+                }
+                else
+                {
+                    context.Result = "No valid workflow type found.";
+                }
+            }
+        }
+    }
+}

--- a/rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "rocks.kfs.WorkflowFromEWS" )]
+[assembly: AssemblyProduct( "rocks.kfs.WorkflowFromEWS" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2019" )]
+
+// Auto increment assembly versions
+[assembly: AssemblyVersion( "1.0.*" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "eefcbe3d-6f6c-4c9b-8a19-b9fa04b4d6bf" )]

--- a/rocks.kfs.WorkflowFromEWS/packages.config
+++ b/rocks.kfs.WorkflowFromEWS/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Exchange.WebServices" version="2.2" targetFramework="net452" />
+</packages>

--- a/rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj
+++ b/rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EEFCBE3D-6F6C-4C9B-8A19-B9FA04B4D6BF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>rocks.kfs.WorkflowFromEWS</RootNamespace>
+    <AssemblyName>rocks.kfs.WorkflowFromEWS</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotLiquid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\DotLiquid.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework">
+      <HintPath>..\..\RockWeb\Bin\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Exchange.WebServices, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Exchange.WebServices.Auth, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
+    </Reference>
+    <Reference Include="Quartz">
+      <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Jobs\StartWorkflow.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

This job uses the Exchange Web Services to connect to an Exchange Server or Office 365 and kicks off a selected Workflow Type.  It can be configured to initiate a Workflow for every message or it can group by Conversation Id and only create one Workflow, appending the body of subsequent messages to an existing Workflow.

---------

### Requested By

##### Who reported, requested, or paid for the change?

KFS

---------

### Screenshots

##### Does this update or add options to the module UI?

![image](https://user-images.githubusercontent.com/3513589/64195510-a9526b80-ce4f-11e9-84c4-bb502a9ae0b1.png)


---------

### Change Log

##### What files does it affect?

* `rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs`
* `rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs`
* `rocks.kfs.WorkflowFromEWS/packages.config`
* `rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj`

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
