### PR TITLE
Feature/nbh reach updates

### DIFF
--- a/rocks.kfs.Reach/Gateway.cs
+++ b/rocks.kfs.Reach/Gateway.cs
@@ -216,6 +216,7 @@ namespace rocks.kfs.Reach
             var donationUrl = GetBaseUrl( gateway, "donations", out errorMessage );
             var supporterUrl = GetBaseUrl( gateway, "sponsorship_supporters", out errorMessage );
             var categoryUrl = GetBaseUrl( gateway, "donation_categories", out errorMessage );
+            var projectsUrl = GetBaseUrl( gateway, "projects", out errorMessage );
 
             if ( donationUrl.IsNullOrWhiteSpace() || supporterUrl.IsNullOrWhiteSpace() )
             {
@@ -247,6 +248,8 @@ namespace rocks.kfs.Reach
             var newTransactions = new List<FinancialTransaction>();
             var categoryResult = Api.PostRequest( categoryUrl, authenticator, null, out errorMessage );
             var categories = JsonConvert.DeserializeObject<List<Reporting.Category>>( categoryResult.ToStringSafe() );
+            var projectResult = Api.PostRequest( categoryUrl, authenticator, null, out errorMessage );
+            var projects = JsonConvert.DeserializeObject<List<Reporting.Project>>( projectResult.ToStringSafe() );
             if ( categories == null )
             {
                 // errorMessage already set
@@ -289,6 +292,15 @@ namespace rocks.kfs.Reach
                                 if ( category != null )
                                 {
                                     reachAccountName = category.title;
+                                }
+                            }
+                            else if ( donationItem != null && donationItem.referral_type.Equals( "Project", StringComparison.InvariantCultureIgnoreCase ) )
+                            {
+                                // one-time gift, should match a known project
+                                var project = projects.FirstOrDefault( c => c.id == donationItem.referral_id );
+                                if ( project != null )
+                                {
+                                    reachAccountName = project.title;
                                 }
                             }
                             else

--- a/rocks.kfs.Reach/Gateway.cs
+++ b/rocks.kfs.Reach/Gateway.cs
@@ -248,7 +248,7 @@ namespace rocks.kfs.Reach
             var newTransactions = new List<FinancialTransaction>();
             var categoryResult = Api.PostRequest( categoryUrl, authenticator, null, out errorMessage );
             var categories = JsonConvert.DeserializeObject<List<Reporting.Category>>( categoryResult.ToStringSafe() );
-            var projectResult = Api.PostRequest( categoryUrl, authenticator, null, out errorMessage );
+            var projectResult = Api.PostRequest( projectsUrl, authenticator, null, out errorMessage );
             var projects = JsonConvert.DeserializeObject<List<Reporting.Project>>( projectResult.ToStringSafe() );
             if ( categories == null )
             {
@@ -300,7 +300,7 @@ namespace rocks.kfs.Reach
                                 var project = projects.FirstOrDefault( c => c.id == donationItem.referral_id );
                                 if ( project != null )
                                 {
-                                    reachAccountName = project.title;
+                                    reachAccountName = string.Format("PROJECT {0}", project.title);
                                 }
                             }
                             else

--- a/rocks.kfs.Reach/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Reach/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2019" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.11.*" )]
+[assembly: AssemblyVersion( "2.0.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Reach/Reporting/Project.cs
+++ b/rocks.kfs.Reach/Reporting/Project.cs
@@ -1,0 +1,66 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+
+namespace rocks.kfs.Reach.Reporting
+{
+    public class Project
+    {
+        public int? id;
+        public int? account_id;
+        public string cover_image_content_type;
+        public string cover_image_file_name;
+        public int? cover_image_file_size;
+        public DateTime? cover_image_updated_at;
+        public CoverImages cover_images;
+        public DateTime? created_at;
+        public string description;
+        public bool disable;
+        public string full_url;
+        public string get_involved;
+        public string image_content_type;
+        public string image_file_name;
+        public int? image_file_size;
+        public DateTime? image_updated_at;
+        public ProjectImages images;
+        public string language;
+        public string leader;
+        public string leader_email;
+        public string leader_phone;
+        public string permalink;
+        public string subtitle;
+        public string title;
+        public DateTime? updated_at;
+        public string url;
+        public string web_address;
+
+    }
+    public class ProjectImages
+    {
+        public string thumbnail;
+        public string small;
+        public string medium;
+        public string large;
+        public string original;
+    }
+
+    public class CoverImages
+    {
+        public string cover;
+        public string original;
+    }
+}

--- a/rocks.kfs.Reach/rocks.kfs.Reach.csproj
+++ b/rocks.kfs.Reach/rocks.kfs.Reach.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Gateway.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporting\Api.cs" />
+    <Compile Include="Reporting\Project.cs" />
     <Compile Include="Reporting\Category.cs" />
     <Compile Include="Reporting\Donation.cs" />
     <Compile Include="Reporting\Supporter.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Adds new ability to synchronize Reach "projects" to specific Rock accounts.

**New Settings:**

Account map defined value must have a map setup to accommodate projects in the following manner:
`PROJECT <projectTitle>` (ex. PROJECT Gristmill)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

**Reach Gateway/download assembly**

* Added capability to handle the new "Project" type added by Reach.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington Church

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Reach/Gateway.cs
- rocks.kfs.Reach/Reporting/Project.cs
- rocks.kfs.Reach/rocks.kfs.Reach.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
