### PR TITLE
Intacct Memo field Lava Support

### DIFF
--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -90,6 +90,7 @@ namespace rocks.kfs.Intacct
         public string Department;
         public string Location;
         public string Project;
+        public string Description;
         public Dictionary<string, dynamic> CustomDimensions;
     }
 }

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -16,6 +16,8 @@
 //
 using System;
 using System.Collections.Generic;
+using Rock;
+using Rock.Data;
 
 namespace rocks.kfs.Intacct
 {
@@ -74,11 +76,106 @@ namespace rocks.kfs.Intacct
         public string WarehouseId;
     }
 
-    public class GLTransaction
+    public class GLTransaction : Rock.Lava.ILiquidizable
     {
+        [LavaInclude]
         public decimal Amount;
+
+        [LavaInclude]
         public int FinancialAccountId;
+
+        [LavaInclude]
         public string Project;
+
+        #region ILiquidizable
+
+        /// <summary>
+        /// Creates a DotLiquid compatible dictionary that represents the current entity object. 
+        /// </summary>
+        /// <returns>DotLiquid compatible dictionary.</returns>
+        public object ToLiquid()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the available keys (for debugging info).
+        /// </summary>
+        /// <value>
+        /// The available keys.
+        /// </value>
+        [LavaIgnore]
+        public virtual List<string> AvailableKeys
+        {
+            get
+            {
+                var availableKeys = new List<string>();
+
+                foreach ( var propInfo in GetType().GetProperties() )
+                {
+                    availableKeys.Add( propInfo.Name );
+                }
+
+                return availableKeys;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="System.Object"/> with the specified key.
+        /// </summary>
+        /// <value>
+        /// The <see cref="System.Object"/>.
+        /// </value>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        [LavaIgnore]
+        public virtual object this[object key]
+        {
+            get
+            {
+                string propertyKey = key.ToStringSafe();
+                var propInfo = GetType().GetProperty( propertyKey );
+
+                try
+                {
+                    object propValue = null;
+                    if ( propInfo != null )
+                    {
+                        propValue = propInfo.GetValue( this, null );
+                    }
+
+                    if ( propValue is Guid )
+                    {
+                        return ( ( Guid ) propValue ).ToString();
+                    }
+                    else
+                    {
+                        return propValue;
+                    }
+                }
+                catch
+                {
+                    // intentionally ignore
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the specified key contains key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        public virtual bool ContainsKey( object key )
+        {
+            string propertyKey = key.ToStringSafe();
+            var propInfo = GetType().GetProperty( propertyKey );
+
+            return propInfo != null;
+        }
+
+        #endregion
     }
 
     public class GLBatchTotals


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added ability to pass in lava to intacct export features to get a customized memo field in intacct export. Fixes #3 

**New Settings:**

- New settings added on https://github.com/KingdomFirst/RockBlocks/pull/7

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added ability to pass in lava to intacct export to get a customized memo field.

---------

### Requested By

##### Who reported, requested, or paid for the change?

OHC

---------

### Screenshots

##### Does this update or add options to the block UI?

See https://github.com/KingdomFirst/RockBlocks/pull/7

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Intacct/IntacctJournal.cs
- rocks.kfs.Intacct/IntacctModels.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, block and assembly must be updated at the same time otherwise you will get mismatched function calls. https://github.com/KingdomFirst/RockBlocks/pull/7
