### PR TITLE
Fundraising Participant Job Minor Tweak

### DIFF
--- a/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
+++ b/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
@@ -168,6 +168,7 @@ namespace rocks.kfs.FundraisingParticipantSummary.Jobs
                             mergeFields.Add( "BeginDateTime", beginDateTime );
                             mergeFields.Add( "FundraisingGoal", individualFundraisingGoal );
                             mergeFields.Add( "AmountLeft", amountLeft );
+                            mergeFields.Add( "ContributionTotal", contributionTotal );
                             mergeFields.Add( "PercentMet", percentMet );
                             mergeFields.Add( "ShowAddress", showAddress );
                             mergeFields.Add( "ShowAmount", showAmount );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add new "ContributionTotal" lava field instead of having to subtract it in the lava again.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Add new `ContributionTotal` lava field instead of having to subtract it in the lava again.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
