### PR TITLE
Reach Update Primary Email Address Setting

### DIFF
--- a/rocks.kfs.Reach/Gateway.cs
+++ b/rocks.kfs.Reach/Gateway.cs
@@ -52,6 +52,7 @@ namespace rocks.kfs.Reach
     [DefinedValueField( Rock.SystemGuid.DefinedType.FINANCIAL_SOURCE_TYPE, "Source Type", "Select the defined value that new transactions should be attributed with.", true, false, "74650f5b-3e18-43e8-88db-1598deb2ffa0", "", 6 )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.PERSON_CONNECTION_STATUS, "Person Status", "Select the defined value that new people should be created with.", true, false, "", "", 7 )]
     [CustomRadioListField( "Mode", "Mode to use for transactions", "Live,Test", true, "Test", "", 7 )]
+    [BooleanField( "Update Primary Email", "Should the Reach account update the primary Rock email on transaction download?", false, "", 8 )]
 
     #endregion
 
@@ -235,6 +236,7 @@ namespace rocks.kfs.Reach
             var connectionStatus = DefinedValueCache.Get( GetAttributeValue( gateway, "PersonStatus" ) );
             var reachSourceType = DefinedValueCache.Get( GetAttributeValue( gateway, "SourceType" ) );
             var defaultAccount = accountLookup.Get( GetAttributeValue( gateway, "DefaultAccount" ).AsGuid() );
+            var updatePrimaryEmail = GetAttributeValue( gateway, "UpdatePrimaryEmail" ).AsBoolean();
             if ( connectionStatus == null || reachAccountMaps == null || reachSourceType == null || defaultAccount == null )
             {
                 errorMessage = "The Reach Account Map, Person Status, Source Type, or Default Account is not configured correctly in gateway settings.";
@@ -281,7 +283,7 @@ namespace rocks.kfs.Reach
                         if ( transaction == null )
                         {
                             // find or create this person asynchronously for performance
-                            var personAlias = Api.FindPersonAsync( lookupContext, donation, connectionStatus.Id );
+                            var personAlias = Api.FindPersonAsync( lookupContext, donation, connectionStatus.Id, updatePrimaryEmail );
 
                             var reachAccountName = string.Empty;
                             var donationItem = donation.line_items.FirstOrDefault();

--- a/rocks.kfs.Reach/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Reach/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.Reach" )]
 [assembly: AssemblyProduct( "rocks.kfs.Reach" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2019" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2020" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.0.*" )]
+[assembly: AssemblyVersion( "2.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Reach/Reporting/Api.cs
+++ b/rocks.kfs.Reach/Reporting/Api.cs
@@ -136,8 +136,9 @@ namespace rocks.kfs.Reach.Reporting
         /// <param name="lookupContext">The lookup context.</param>
         /// <param name="donation">The donation.</param>
         /// <param name="connectionStatusId">The connection status identifier.</param>
+        /// <param name="updatePrimaryEmail">Whether or not this method should update the primary email address on the person.</param>
         /// <returns></returns>
-        public static Task<int?> FindPersonAsync( RockContext lookupContext, Donation donation, int connectionStatusId )
+        public static Task<int?> FindPersonAsync( RockContext lookupContext, Donation donation, int connectionStatusId, bool updatePrimaryEmail )
         {
             // specifically using Task.Run instead of Task.Factory.StartNew( longRunning)
             // see https://blog.stephencleary.com/2013/08/startnew-is-dangerous.html
@@ -146,7 +147,7 @@ namespace rocks.kfs.Reach.Reporting
                 // look for a single existing person by person fields
                 int? primaryAliasId = null;
                 var reachSearchKey = string.Format( "{0}_{1}", donation.supporter_id, "reach" );
-                var person = new PersonService( lookupContext ).FindPerson( donation.first_name, donation.last_name, donation.email, true, true );
+                var person = new PersonService( lookupContext ).FindPerson( donation.first_name, donation.last_name, donation.email, updatePrimaryEmail, true );
                 if ( person == null )
                 {
                     // check by the search key


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

+ Added a new setting to disable "Update Primary Email" when matching a person record.

**New Settings:**

`Update Primary Email`

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added a new setting to disable "Update Primary Email" when matching a person record.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/81444110-d7512380-9133-11ea-9d8b-ec3b2eafc230.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Reach/Gateway.cs
- rocks.kfs.Reach/Properties/AssemblyInfo.cs
- rocks.kfs.Reach/Reporting/Api.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No