### PR TITLE
Rock Job EWS to Workflow Bug Fix

### DIFF
--- a/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
@@ -149,7 +149,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                                         existingWorkflow = new WorkflowService( rockContext )
                                             .Queryable()
                                             .AsNoTracking()
-                                            .FirstOrDefault( w => w.IsActive && w.ForeignKey.Equals( foreignKey, StringComparison.Ordinal ) );
+                                            .FirstOrDefault( w => w.ActivatedDateTime.HasValue && !w.CompletedDateTime.HasValue && w.ForeignKey.Equals( foreignKey, StringComparison.Ordinal ) );
 
                                         createWorkflow = existingWorkflow.IsNull();
                                     }

--- a/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs
@@ -116,7 +116,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
                             var sf = new SearchFilter.SearchFilterCollection( LogicalOperator.And, new SearchFilter.IsEqualTo( EmailMessageSchema.IsRead, false ) );
                             var view = new ItemView( maxEmails );
                             view.PropertySet = findItemPropertySet;
-                            view.OrderBy.Add( ItemSchema.DateTimeReceived, SortDirection.Ascending );
+                            view.OrderBy.Add( ItemSchema.DateTimeReceived, SortDirection.Descending );
                             var findResults = service.FindItems( folderId, sf, view );
 
                             if ( findResults.Items.Count > 0 )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for IsActive workflow, not an actual database member, changed to check the fields the method does. Changed Sort order to OrderBy Date *Descending* due to using it in a group with no deleted emails.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed checking for existing active workflows that generated an exception.
- Changed Sort order to OrderBy Date *Descending* due to using it in a group with no deleted emails.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No