### PR TITLE
Scheduled Group Communication Fix

### DIFF
--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
@@ -34,6 +34,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
 {
     [LavaCommandsField( "Enabled Lava Commands", "The Lava commands that should be enabled for this job.", false, order: 0 )]
     [IntegerField( "Command Timeout", "Maximum amount of time (in seconds) to wait for the each group communication creation to complete.", false, 180, "General", 1, "CommandTimeout" )]
+    [IntegerField( "Last Run Buffer", "Use this setting to add a buffer to not double send, too large of a buffer may cause messages to be missed. By default this job will send any communications that have been scheduled since the last run date time minus the LastRunDurationSeconds, due to the way some server schedules run it is possible to be a few seconds off and double send.", false, -5, "General", 2 )]
 
     /// <summary>
     /// Job to send scheduled group emails.
@@ -63,6 +64,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
         {
             var dataMap = context.JobDetail.JobDataMap;
             int? commandTimeout = dataMap.GetString( "CommandTimeout" ).AsIntegerOrNull();
+            int? lastRunBuffer = dataMap.GetString( "LastRunBuffer" ).AsIntegerOrNull();
             var enabledLavaCommands = dataMap.GetString( "EnabledLavaCommands" );
             var JobStartDateTime = RockDateTime.Now;
             var dateAttributes = new List<AttributeValue>();
@@ -91,7 +93,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
 
                     if ( job != null && job.Guid != Rock.SystemGuid.ServiceJob.JOB_PULSE.AsGuid() )
                     {
-                        lastStartDateTime = job.LastRunDateTime?.AddSeconds( 0.0d - ( double ) job.LastRunDurationSeconds );
+                        lastStartDateTime = job.LastRunDateTime?.AddSeconds( 0.0d - ( double ) ( job.LastRunDurationSeconds + lastRunBuffer ) );
                     }
                     var beginDateTime = lastStartDateTime ?? JobStartDateTime.AddDays( -1 );
 

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -34,6 +34,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
 {
     [LavaCommandsField( "Enabled Lava Commands", "The Lava commands that should be enabled for this job.", false, order: 0 )]
     [IntegerField( "Command Timeout", "Maximum amount of time (in seconds) to wait for the each group communication creation to complete.", false, 180, "General", 1, "CommandTimeout" )]
+    [IntegerField( "Last Run Buffer", "Use this setting to add a buffer to not double send, too large of a buffer may cause messages to be missed. By default this job will send any communications that have been scheduled since the last run date time minus the LastRunDurationSeconds, due to the way some server schedules run it is possible to be a few seconds off and double send.", false, -5, "General", 2 )]
 
     /// <summary>
     /// Job to send scheduled group SMS messages.
@@ -63,6 +64,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
         {
             var dataMap = context.JobDetail.JobDataMap;
             int? commandTimeout = dataMap.GetString( "CommandTimeout" ).AsIntegerOrNull();
+            int? lastRunBuffer = dataMap.GetString( "LastRunBuffer" ).AsIntegerOrNull();
             var enabledLavaCommands = dataMap.GetString( "EnabledLavaCommands" );
             var JobStartDateTime = RockDateTime.Now;
             var dateAttributes = new List<AttributeValue>();
@@ -89,7 +91,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
 
                     if ( job != null && job.Guid != Rock.SystemGuid.ServiceJob.JOB_PULSE.AsGuid() )
                     {
-                        lastStartDateTime = job.LastRunDateTime?.AddSeconds( 0.0d - ( double ) job.LastRunDurationSeconds );
+                        lastStartDateTime = job.LastRunDateTime?.AddSeconds( 0.0d - ( double ) ( job.LastRunDurationSeconds + lastRunBuffer ) );
                     }
                     var beginDateTime = lastStartDateTime ?? JobStartDateTime.AddDays( -1 );
 

--- a/rocks.kfs.ScheduledGroupCommunication/Migrations/001_AddSystemData.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Migrations/001_AddSystemData.cs
@@ -94,7 +94,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Migrations
             }
             else
             {
-                // create the attirbute matrix template and get it's id to assign to the attributes we'll create
+                // create the attribute matrix template and get it's id to assign to the attributes we'll create
                 var attributeMatrixTemplateEmail = new AttributeMatrixTemplate
                 {
                     Name = "Scheduled Emails",


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

+ Added a possible fix for duplicate scheduled group communications. (Fixes https://github.com/KingdomFirst/RockBlocks/issues/21)

**New Settings:**

- **Last Run Buffer**: Use this setting to add a buffer to not double send, too large of a buffer may cause messages to be missed. By default this job will send any communications that have been scheduled since the last run date time minus the LastRunDurationSeconds, due to the way some server schedules run it is possible to be a few seconds off and double send.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

+ Added a possible fix for duplicate scheduled group communications.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty/Biltmore

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/90198903-681d4800-dd90-11ea-9611-0581a6aad7de.png)


---------

### Change Log

##### What files does it affect?

rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
rocks.kfs.ScheduledGroupCommunication/Migrations/001_AddSystemData.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No