### PR TITLE
Minor fixes for obsolete methods.

### DIFF
--- a/rocks.kfs.CampusEngagementEmailSend/Jobs/CampusEngagementEmailSend.cs
+++ b/rocks.kfs.CampusEngagementEmailSend/Jobs/CampusEngagementEmailSend.cs
@@ -173,8 +173,8 @@ namespace rocks.kfs.CampusEngagementEmailSend.Jobs
                         mergeObjects.Add( "GroupAttendance", groupAttendanceOccurrences );
                         mergeObjects.Add( "Campus", campus );
 
-                        var recipients = new List<RecipientData>();
-                        recipients.Add( new RecipientData( email, mergeObjects ) );
+                        var recipients = new List<RockEmailMessageRecipient>();
+                        recipients.Add( new RockEmailMessageRecipient( pastor, mergeObjects ) );
 
                         var emailMessage = new RockEmailMessage( systemEmailGuid );
                         emailMessage.SetRecipients( recipients );

--- a/rocks.kfs.GroupRoleAttendanceReminder/Jobs/GroupRoleSendAttendanceReminders.cs
+++ b/rocks.kfs.GroupRoleAttendanceReminder/Jobs/GroupRoleSendAttendanceReminders.cs
@@ -327,8 +327,8 @@ namespace rocks.kfs.GroupRoleAttendanceReminder.Jobs
                 mergeObjects.Add( "Group", group );
                 mergeObjects.Add( "Occurrence", occGroup.Value.Max() );
 
-                var recipients = new List<RecipientData>();
-                recipients.Add( new RecipientData( email, mergeObjects ) );
+                var recipients = new List<RockEmailMessageRecipient>();
+                recipients.Add( RockEmailMessageRecipient.CreateAnonymous( email, mergeObjects ) );
 
                 var emailMessage = new RockEmailMessage( systemEmailGuid );
                 emailMessage.SetRecipients( recipients );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Minor fixes for obsolete methods. RecipientData replaced with RockEmailMessageRecipient.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- RecipientData methods replaced with RockEmailMessageRecipient.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.CampusEngagementEmailSend/Jobs/CampusEngagementEmailSend.cs
- rocks.kfs.GroupRoleAttendanceReminder/Jobs/GroupRoleSendAttendanceReminders.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No