### PR TITLE
Eventbrite Null Reference Fix

### DIFF
--- a/rocks.kfs.EventBrite/Eventbrite.cs
+++ b/rocks.kfs.EventBrite/Eventbrite.cs
@@ -504,10 +504,11 @@ namespace rocks.kfs.Eventbrite
                 LogEvent( rockContext, "SetPersonData", string.Format( "Person: {0} Attendee: {1} Group: {2}", person, attendee.Id, group ), "Start" );
             }
 
+            var familyGroup = person.GetFamily( rockContext );
+
             //Address
-            if ( attendee.Profile.Addresses.Home != null && attendee.Profile.Addresses.Home.Address_1 != null && !person.PrimaryFamily.GroupLocations.Any( gl => gl.GroupLocationTypeValueId == homeLocationValueId ) )
+            if ( attendee.Profile.Addresses.Home != null && attendee.Profile.Addresses.Home.Address_1 != null &&  familyGroup != null && familyGroup.GroupLocations != null && !familyGroup.GroupLocations.Any( gl => gl.GroupLocationTypeValueId == homeLocationValueId )  )
             {
-                var familyGroup = person.GetFamily( rockContext );
                 var location = new LocationService( rockContext ).Get( attendee.Profile.Addresses.Home.Address_1, attendee.Profile.Addresses.Home.Address_2, attendee.Profile.Addresses.Home.City, attendee.Profile.Addresses.Home.Region, attendee.Profile.Addresses.Home.Postal_Code, attendee.Profile.Addresses.Home.Country );
                 if ( familyGroup != null && location != null )
                 {

--- a/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
@@ -5,22 +5,22 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("rocks.kfs.Eventbrite")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Kingdom First Solutions")]
-[assembly: AssemblyProduct("rocks.kfs.Eventbrite")]
-[assembly: AssemblyCopyright("Copyright © Kingdom First Solutions 2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyTitle( "rocks.kfs.Eventbrite" )]
+[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "Kingdom First Solutions" )]
+[assembly: AssemblyProduct( "rocks.kfs.Eventbrite" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+[assembly: ComVisible( false )]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("03f6895a-adf6-4c18-89cc-71ed605b4afb")]
+[assembly: Guid( "03f6895a-adf6-4c18-89cc-71ed605b4afb" )]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Got a null reference exception when I ran Eventbrite sync locally, decided to fix it so I could test another potential issue. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed a potential null reference exception when Rock would not return a primary family. 

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.EventBrite/Eventbrite.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
