### PR TITLE
Eventbrite Organization Fix

### DIFF
--- a/rocks.kfs.EventBrite/Entities/RockEventbriteEvent.cs
+++ b/rocks.kfs.EventBrite/Entities/RockEventbriteEvent.cs
@@ -157,7 +157,7 @@ namespace EventbriteDotNetFramework.Entities
             }
             if ( _evntId > 0 )
             {
-                _eb = new EBApi( Settings.GetAccessToken() );
+                _eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
                 _ebevent = _eb.GetEventById( _evntId );
             }
         }

--- a/rocks.kfs.EventBrite/Eventbrite.cs
+++ b/rocks.kfs.EventBrite/Eventbrite.cs
@@ -44,12 +44,16 @@ namespace rocks.kfs.Eventbrite
 
         public static EBApi Api()
         {
-            return new EBApi( Settings.GetAccessToken() );
+            return new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
         }
 
         public static EBApi Api( string oAuthToken )
         {
             return new EBApi( oAuthToken );
+        }
+        public static EBApi Api( string oAuthToken, long orgId )
+        {
+            return new EBApi( oAuthToken, orgId );
         }
 
         public static bool EBUsageCheck( int id )
@@ -171,7 +175,7 @@ namespace rocks.kfs.Eventbrite
             }
 
             var group = new GroupService( rockContext ).Get( groupid );
-            var eb = new EBApi( Settings.GetAccessToken() );
+            var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
             var groupEBEventIDAttr = GetGroupEBEventId( group );
             var groupEBEventAttrSplit = groupEBEventIDAttr.Value.SplitDelimitedValues( "^" );
             var evntid = long.Parse( groupEBEventIDAttr != null ? groupEBEventAttrSplit[0] : "0" );
@@ -244,7 +248,7 @@ namespace rocks.kfs.Eventbrite
         }
         public static void SyncOrder( string apiUrl )
         {
-            var eb = new EBApi( Settings.GetAccessToken() );
+            var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
             var order = eb.GetOrder( apiUrl, "event,attendees" );
             var rockContext = new RockContext();
             var group = GetGroupByEBEventId( order.Event_Id, rockContext );
@@ -275,7 +279,7 @@ namespace rocks.kfs.Eventbrite
 
         public static void SyncAttendee( string apiUrl )
         {
-            var eb = new EBApi( Settings.GetAccessToken() );
+            var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
             var attendee = eb.GetAttendee( apiUrl, "event,order" );
             var order = attendee.Order;
             var rockContext = new RockContext();

--- a/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
+++ b/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
@@ -50,7 +50,7 @@ namespace rocks.kfs.Eventbrite.Field.Types
         {
             string formattedValue = value;
             var splitVal = value.SplitDelimitedValues( "^" );
-            long? longVal = splitVal[0].AsLongOrNull();
+            long? longVal = ( splitVal.Count() > 0 ) ? splitVal[0].AsLongOrNull() : null;
             if ( longVal.HasValue )
             {
                 var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );

--- a/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
+++ b/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
@@ -53,7 +53,7 @@ namespace rocks.kfs.Eventbrite.Field.Types
             long? longVal = splitVal[0].AsLongOrNull();
             if ( longVal.HasValue )
             {
-                var eb = new EBApi( Settings.GetAccessToken() );
+                var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
                 var eventbriteEvent = eb.GetEventById( longVal.Value );
                 var linkedEventTickets = eb.GetTicketsById( longVal.Value );
                 var sold = 0;
@@ -105,7 +105,7 @@ namespace rocks.kfs.Eventbrite.Field.Types
             var parentControl = new Panel();
             var editControl = new RockDropDownList { ID = id };
             editControl.Items.Add( new ListItem() );
-            var eb = new EBApi( Settings.GetAccessToken() );
+            var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
 
             var organizationEvents = eb.GetOrganizationEvents( "all", 500 );
             if ( organizationEvents.Pagination.Has_More_Items )

--- a/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Organization that was stored in settings was not being taken into account properly.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed issue where Organization may not be taken into account when running any Eventbrite sync methods.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Support

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.EventBrite/Entities/RockEventbriteEvent.cs
- rocks.kfs.EventBrite/Eventbrite.cs
- rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, existing methods should still work.
