### PR TITLE
F: gm-scheduledGroupComm

### DIFF
--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
@@ -189,7 +189,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                 {
                                     personIdHash.Add( member.PersonId );
                                     var communicationRecipient = new CommunicationRecipient();
-                                    communicationRecipient.PersonAliasId = member.Person.PrimaryAliasId.Value;
+                                    communicationRecipient.PersonAliasId = member.Person.PrimaryAliasId;
                                     communicationRecipient.AdditionalMergeValues = new Dictionary<string, object>();
                                     communicationRecipient.AdditionalMergeValues.Add( "GroupMember", member );
                                     //communicationRecipient.AdditionalMergeValues.Add( "Group", group );
@@ -219,23 +219,22 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                             communicationsSent += personIdHash.Count;
 
                             var recurrence = new AttributeValueService( rockContext )
-                                .GetByAttributeIdAndEntityId( recurrenceAttributeId, attributeMatrixItemAndGroupId.Key )
-                                .Value;
+                                .GetByAttributeIdAndEntityId( recurrenceAttributeId, attributeMatrixItemAndGroupId.Key );
 
-                            if ( !string.IsNullOrWhiteSpace( recurrence ) )
+                            if ( recurrence != null && !string.IsNullOrWhiteSpace( recurrence.Value ) )
                             {
                                 var sendDate = new AttributeValueService( rockContext )
                                     .GetByAttributeIdAndEntityId( dateAttributeId, attributeMatrixItemAndGroupId.Key );
 
-                                switch ( recurrence )
+                                switch ( recurrence.Value )
                                 {
-                                    case "Weekly":
+                                    case "1":
                                         sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 7 ).ToString();
                                         break;
-                                    case "BiWeekly":
+                                    case "2":
                                         sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 14 ).ToString();
                                         break;
-                                    case "Monthly":
+                                    case "3":
                                         sendDate.Value = sendDate.ValueAsDateTime.Value.AddMonths( 1 ).ToString();
                                         break;
                                     default:

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -187,7 +187,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                             {
                                                 personIdHash.Add( groupMember.PersonId );
                                                 var communicationRecipient = new CommunicationRecipient();
-                                                communicationRecipient.PersonAliasId = person.PrimaryAliasId.Value;
+                                                communicationRecipient.PersonAliasId = person.PrimaryAliasId;
                                                 communicationRecipient.AdditionalMergeValues = new Dictionary<string, object>();
                                                 communicationRecipient.AdditionalMergeValues.Add( "GroupMember", groupMember );
                                                 //communicationRecipient.AdditionalMergeValues.Add( "Group", group );
@@ -218,23 +218,22 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                 communicationsSent = communicationsSent + personIdHash.Count;
 
                                 var recurrence = new AttributeValueService( rockContext )
-                                    .GetByAttributeIdAndEntityId( recurrenceAttributeId, attributeMatrixItemAndGroupId.Key )
-                                    .Value;
+                                    .GetByAttributeIdAndEntityId( recurrenceAttributeId, attributeMatrixItemAndGroupId.Key );
 
-                                if ( !string.IsNullOrWhiteSpace( recurrence ) )
+                                if ( recurrence != null && !string.IsNullOrWhiteSpace( recurrence.Value ) )
                                 {
                                     var sendDate = new AttributeValueService( rockContext )
                                         .GetByAttributeIdAndEntityId( dateAttributeId, attributeMatrixItemAndGroupId.Key );
 
-                                    switch ( recurrence )
+                                    switch ( recurrence.Value )
                                     {
-                                        case "Weekly":
+                                        case "1":
                                             sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 7 ).ToString();
                                             break;
-                                        case "BiWeekly":
+                                        case "2":
                                             sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 14 ).ToString();
                                             break;
-                                        case "Monthly":
+                                        case "3":
                                             sendDate.Value = sendDate.ValueAsDateTime.Value.AddMonths( 1 ).ToString();
                                             break;
                                         default:

--- a/rocks.kfs.ScheduledGroupCommunication/Migrations/002_AddRecurrenceAttribute.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Migrations/002_AddRecurrenceAttribute.cs
@@ -1,0 +1,93 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.ScheduledGroupCommunication.SystemGuid;
+
+namespace rocks.kfs.ScheduledGroupCommunication.Migrations
+{
+    [MigrationNumber( 2, "1.7.4" )]
+    internal class AddRecurrenceAttribute : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            #region Email Attribute
+
+            var attributeMatrixTemplateEmailId = new AttributeMatrixTemplateService( new RockContext() ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_EMAILS.AsGuid() ).Id.ToString();
+
+            // recurrence attribute
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "Recurrence", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.EmailSendRecurrence" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "values", "OneTime,Weekly,BiWeekly,Monthly", "F1F0873E-CA36-4935-90F5-DFEFD79083C8" );
+
+            // reorder existing matrix attributes
+
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.EMAIL, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "From Email", "", 2, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_FROM_EMAIL, "rocks.kfs.ScheduledGroupCommunication.EmailFromAddress" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.TEXT, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "From Name", "", 3, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_FROM_NAME, "rocks.kfs.ScheduledGroupCommunication.EmailFromName" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.TEXT, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "Subject", "", 4, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SUBJECT, "rocks.kfs.ScheduledGroupCommunication.EmailSubject" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.HTML, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "Message", "", 5, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_MESSAGE, "rocks.kfs.ScheduledGroupCommunication.EmailMessage" );
+
+            // set attribute to be required
+            Sql( @"
+            UPDATE [Attribute] SET [IsRequired] = 1
+            WHERE (
+                [Guid] = '9BC4F790-A9F7-4822-AEEE-91095A3E3D4C'
+            )
+            " );
+
+            #endregion
+
+            #region SMS Attributes
+
+            var rockContextSMS = new RockContext();
+            var attributeMatrixTemplateSMSId = new AttributeMatrixTemplateService( rockContextSMS ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS.AsGuid() ).Id.ToString();
+
+            // recurrence attribute
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "Recurrence", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.SMSSendRecurrence" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "values", "OneTime,Weekly,BiWeekly,Monthly", "4FAE15C5-C1AB-4FDB-B21D-CBF467B1D395" );
+
+            // reorder existing matrix attributes
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.DEFINED_VALUE, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "From Number", "", 2, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "rocks.kfs.ScheduledGroupCommunication.SMSFromNumber" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.MEMO, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "Message", "", 3, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_MESSAGE, "rocks.kfs.ScheduledGroupCommunication.SMSMessage" );
+
+            // set attribute to be required
+            Sql( @"
+            UPDATE [Attribute] SET [IsRequired] = 1
+            WHERE (
+                [Guid] = 'EC6D13F7-A256-4B03-A94B-3B713F26E62D'
+            )
+            " );
+
+            #endregion
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE );
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE );
+        }
+    }
+}

--- a/rocks.kfs.ScheduledGroupCommunication/Migrations/002_AddRecurrenceAttribute.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Migrations/002_AddRecurrenceAttribute.cs
@@ -37,8 +37,8 @@ namespace rocks.kfs.ScheduledGroupCommunication.Migrations
             var attributeMatrixTemplateEmailId = new AttributeMatrixTemplateService( new RockContext() ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_EMAILS.AsGuid() ).Id.ToString();
 
             // recurrence attribute
-            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "Recurrence", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.EmailSendRecurrence" );
-            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "values", "OneTime,Weekly,BiWeekly,Monthly", "F1F0873E-CA36-4935-90F5-DFEFD79083C8" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateEmailId, "Recurrence", "", 1, "0", KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.EmailSendRecurrence" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "values", "0^OneTime,1^Weekly,2^BiWeekly,3^Monthly", "F1F0873E-CA36-4935-90F5-DFEFD79083C8" );
 
             // reorder existing matrix attributes
 
@@ -63,8 +63,8 @@ namespace rocks.kfs.ScheduledGroupCommunication.Migrations
             var attributeMatrixTemplateSMSId = new AttributeMatrixTemplateService( rockContextSMS ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS.AsGuid() ).Id.ToString();
 
             // recurrence attribute
-            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "Recurrence", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.SMSSendRecurrence" );
-            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "values", "OneTime,Weekly,BiWeekly,Monthly", "4FAE15C5-C1AB-4FDB-B21D-CBF467B1D395" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SINGLE_SELECT, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "Recurrence", "", 1, "0", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "rocks.kfs.ScheduledGroupCommunication.SMSSendRecurrence" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "values", "0^OneTime,1^Weekly,2^BiWeekly,3^Monthly", "4FAE15C5-C1AB-4FDB-B21D-CBF467B1D395" );
 
             // reorder existing matrix attributes
             RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.DEFINED_VALUE, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "From Number", "", 2, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "rocks.kfs.ScheduledGroupCommunication.SMSFromNumber" );

--- a/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.5.*" )]
+[assembly: AssemblyVersion( "1.6.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
@@ -34,6 +34,11 @@ namespace rocks.kfs.ScheduledGroupCommunication.SystemGuid
         public const string MATRIX_ATTRIBUTE_EMAIL_SEND_DATE = "39A38B02-112C-4EDC-A30E-4BDB1B090EE4";
 
         /// <summary>
+        /// The matrix attribute for email send recurrence
+        /// </summary>
+        public const string MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE = "9BC4F790-A9F7-4822-AEEE-91095A3E3D4C";
+
+        /// <summary>
         /// The matrix attribute for email from address
         /// </summary>
         public const string MATRIX_ATTRIBUTE_EMAIL_FROM_EMAIL = "F7C73002-6442-4756-BFDB-BC0BFE58EF15";
@@ -63,17 +68,22 @@ namespace rocks.kfs.ScheduledGroupCommunication.SystemGuid
         public const string ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS = "B40C318D-0EB5-49CD-B93C-1CDA0F5CB4BC";
 
         /// <summary>
-        /// The matrix attribute for email send date
+        /// The matrix attribute for SMS send date
         /// </summary>
         public const string MATRIX_ATTRIBUTE_SMS_SEND_DATE = "B2125940-565B-42CE-82BE-CDA58FC65FDE";
 
         /// <summary>
-        /// The matrix attribute for email from address
+        /// The matrix attribute for SMS send recurrence
+        /// </summary>
+        public const string MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE = "EC6D13F7-A256-4B03-A94B-3B713F26E62D";
+
+        /// <summary>
+        /// The matrix attribute for SMS from address
         /// </summary>
         public const string MATRIX_ATTRIBUTE_SMS_FROM_NUMBER = "1984A561-C4A9-4D4F-B366-23AD54BDCFE8";
 
         /// <summary>
-        /// The matrix attribute for email message
+        /// The matrix attribute for SMS message
         /// </summary>
         public const string MATRIX_ATTRIBUTE_SMS_MESSAGE = "C57166D5-C0D3-4DA6-88DD-92AFA5126D69";
 

--- a/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
+++ b/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Jobs\SendScheduledGroupEmail.cs" />
     <Compile Include="Jobs\SendScheduledGroupSMS.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />
+    <Compile Include="Migrations\002_AddRecurrenceAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SystemGuid\Attribute.cs" />
   </ItemGroup>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

* Added "Recurrence" single select attribute to Scheduled Emails and Scheduled SMS Messages attribute matrix templates. The single select attribute has values of OneTime, Weekly, BiWeekly, and Monthly.  
* Added logic to KFS SendScheduledGroupEmail and SendScheduledGroupSMS jobs to handle recurrence. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added "Recurrence" single select attribute to Scheduled Emails and Scheduled SMS Messages attribute matrix templates. The single select attribute has values of OneTime, Weekly, BiWeekly, and Monthly.  
* Added logic to KFS SendScheduledGroupEmail and SendScheduledGroupSMS jobs to handle recurrence.   

---------

### Requested By

##### Who reported, requested, or paid for the change?

First Presbyterian Church of Greenville, SC

---------

### Screenshots

##### Does this update or add options to the block UI?

New Recurrence attribute in Group Type edit screen:  
Email Matrix Attribute
![image](https://user-images.githubusercontent.com/7374281/122833918-b73ede00-d2bb-11eb-8a10-e268c432ead2.png)
  
 SMS Matrix Attribute
 ![image](https://user-images.githubusercontent.com/7374281/122833995-d5a4d980-d2bb-11eb-95cc-b35e27dca83d.png)

---------

### Change Log

##### What files does it affect?

* rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
* rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
* rocks.kfs.ScheduledGroupCommunication/Migrations/002_AddRecurrenceAttribute.cs
* rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
* rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
