### PR TITLE
New Check-in Workflow Action

### DIFF
--- a/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
+++ b/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
@@ -1,11 +1,11 @@
 ﻿// <copyright>
-// Copyright by the Spark Development Network
+// Copyright 2021 by Kingdom First Solutions
 //
-// Licensed under the Rock Community License (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.rockrms.com/license
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-//
-// <notice>
-// This file contains modifications by Kingdom First Solutions
-// and is a derivative work.
-//
-// Modification (including but not limited to):
-// * Added the ability to add messages to check-in state during different points of time in workflow actions.
-// </notice>
 //
 using System;
 using System.Collections.Generic;
@@ -49,6 +41,7 @@ namespace rocks.kfs.Workflow.Action.CheckIn
 
     #region Action Settings
     [LavaField( "Error Message Template", "This will be the error message that gets attached to the check-in state for this instance of the action. Logic can be applied based on 'RemovedPeople', 'RemovedGroupTypes', 'RemovedGroups' and 'RemovedLocations'. If you return an empty message it will not display for this instance in our block.", true, "Check-in empty at this point. Customize this error message for where you insert it in the process. " )]
+    [BooleanField( "Always Log Lava", "Enable this if you want the message to be created no matter the result. By default it will only create a message if all people will be removed, such as when your whole family is already checked in or the classrooms are full.", false )]
     #endregion
 
     /// <summary>
@@ -71,14 +64,13 @@ namespace rocks.kfs.Workflow.Action.CheckIn
             if ( checkInState != null )
             {
                 string errorMessageTemplate = GetAttributeValue( action, "ErrorMessageTemplate" );
+                bool logLava = GetAttributeValue( action, "AlwaysLogLava" ).AsBoolean();
 
                 var peopleRemoved = new List<int>();
                 // personId, list of Group Types removed
                 var totalGroupTypesRemoved = new List<Dictionary<int, List<int>>>();
                 // groupTypeId, list of Groups removed
                 var totalGroupsRemoved = new List<Dictionary<int, List<int>>>();
-                // groupId, list of Locations removed
-                var totallocationsRemoved = new List<Dictionary<int, List<int>>>();
 
                 foreach ( var family in checkInState.CheckIn.Families.ToList() )
                 {
@@ -90,33 +82,28 @@ namespace rocks.kfs.Workflow.Action.CheckIn
                             var groupsRemoved = new List<int>();
                             foreach ( var group in groupType.Groups.ToList() )
                             {
-                                //var locationsRemoved = new List<int>();
-                                //foreach ( var location in group.Locations.ToList() )
-                                //{
-                                //    if ( location.Schedules.Count == 0 || !location.Schedules.Any( s => !s.ExcludedByFilter ) )
-                                //    {
-                                //        locationsRemoved.Add( location.Location.Id );
-                                //    }
-                                //}
-                                //var dLocations = new Dictionary<int, List<int>>();
-                                //dLocations.Add( group.Group.Id, locationsRemoved );
-                                //totalGroupsRemoved.Add( dLocations );
                                 if ( group.Locations.Count == 0 || !group.Locations.Any( l => !l.ExcludedByFilter ) )
                                 {
                                     groupsRemoved.Add( group.Group.Id );
                                 }
                             }
-                            var dGroups = new Dictionary<int, List<int>>();
-                            dGroups.Add( groupType.GroupType.Id, groupsRemoved );
-                            totalGroupsRemoved.Add( dGroups );
+                            if ( groupsRemoved.Count > 0 )
+                            {
+                                var dGroups = new Dictionary<int, List<int>>();
+                                dGroups.Add( groupType.GroupType.Id, groupsRemoved );
+                                totalGroupsRemoved.Add( dGroups );
+                            }
                             if ( groupType.Groups.Count == 0 || !groupType.Groups.Any( g => !groupsRemoved.Contains( g.Group.Id ) ) || !groupType.Groups.Any( g => !g.ExcludedByFilter ) )
                             {
                                 groupTypesRemoved.Add( groupType.GroupType.Id );
                             }
                         }
-                        var dGroupTypes = new Dictionary<int, List<int>>();
-                        dGroupTypes.Add( person.Person.Id, groupTypesRemoved );
-                        totalGroupTypesRemoved.Add( dGroupTypes );
+                        if ( groupTypesRemoved.Count > 0 )
+                        {
+                            var dGroupTypes = new Dictionary<int, List<int>>();
+                            dGroupTypes.Add( person.Person.Id, groupTypesRemoved );
+                            totalGroupTypesRemoved.Add( dGroupTypes );
+                        }
                         if ( person.GroupTypes.Count == 0 || person.GroupTypes.All( gt => groupTypesRemoved.Contains( gt.GroupType.Id ) ) || person.GroupTypes.All( t => t.ExcludedByFilter ) )
                         {
                             peopleRemoved.Add( person.Person.Id );
@@ -137,7 +124,7 @@ namespace rocks.kfs.Workflow.Action.CheckIn
                         checkInState.CheckIn.Families.All( f => f.CheckOutPeople.Count == 0 || !f.CheckOutPeople.Any( fp => !peopleRemoved.Contains( fp.Person.Id ) ) )
                     )
                 );
-                if ( noMatchingFamilies )
+                if ( logLava || noMatchingFamilies )
                 {
                     var mergeFields = new Dictionary<string, object>();
                     mergeFields.Add( "CurrentFamily", checkInState.CheckIn.CurrentFamily );
@@ -148,7 +135,7 @@ namespace rocks.kfs.Workflow.Action.CheckIn
                     mergeFields.Add( "RemovedPeople", peopleRemoved );
                     mergeFields.Add( "RemovedGroupTypes", totalGroupTypesRemoved );
                     mergeFields.Add( "RemovedGroups", totalGroupsRemoved );
-                    mergeFields.Add( "RemovedLocations", totallocationsRemoved );
+                    mergeFields.Add( "NoMatchingFamilies", noMatchingFamilies );
 
                     checkInState.Messages.Add( new CheckInMessage { MessageText = errorMessageTemplate.ResolveMergeFields( mergeFields, checkInState.CheckIn.CurrentPerson?.Person ), MessageType = MessageType.Warning } );
                 }

--- a/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
+++ b/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
@@ -136,6 +136,7 @@ namespace rocks.kfs.Workflow.Action.CheckIn
                     mergeFields.Add( "RemovedGroupTypes", totalGroupTypesRemoved );
                     mergeFields.Add( "RemovedGroups", totalGroupsRemoved );
                     mergeFields.Add( "NoMatchingFamilies", noMatchingFamilies );
+                    mergeFields.Add( "ManagerLoggedIn", checkInState.ManagerLoggedIn );
 
                     checkInState.Messages.Add( new CheckInMessage { MessageText = errorMessageTemplate.ResolveMergeFields( mergeFields, checkInState.CheckIn.CurrentPerson?.Person ), MessageType = MessageType.Warning } );
                 }

--- a/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
+++ b/rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
@@ -1,0 +1,147 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+// <notice>
+// This file contains modifications by Kingdom First Solutions
+// and is a derivative work.
+//
+// Modification (including but not limited to):
+// * Added the ability to add messages to check-in state during different points of time in workflow actions.
+// </notice>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Rock;
+using Rock.Attribute;
+using Rock.CheckIn;
+using Rock.Data;
+using Rock.Model;
+using Rock.Workflow;
+using Rock.Workflow.Action.CheckIn;
+
+namespace rocks.kfs.Workflow.Action.CheckIn
+{
+    #region Action Attributes
+
+    [ActionCategory( "KFS: Check-In" )]
+    [Description( "Check for Empty Check-in session due to thresholds, already checked-in, etc." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Check for Empty Check-in" )]
+
+    #endregion
+
+    #region Action Settings
+    [LavaField( "Error Message Template", "This will be the error message that gets attached to the check-in state for this instance of the action. Logic can be applied based on 'RemovedPeople', 'RemovedGroupTypes', 'RemovedGroups' and 'RemovedLocations'. If you return an empty message it will not display for this instance in our block.", true, "Check-in empty at this point. Customize this error message for where you insert it in the process. " )]
+    #endregion
+
+    /// <summary>
+    /// Adds the locations for each members group types
+    /// </summary>
+    public class CheckForEmptyCheckin : CheckInActionComponent
+    {
+        /// <summary>
+        /// Executes the specified workflow.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The workflow action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public override bool Execute( RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages )
+        {
+            var checkInState = GetCheckInState( entity, out errorMessages );
+            if ( checkInState != null )
+            {
+                string errorMessageTemplate = GetAttributeValue( action, "ErrorMessageTemplate" );
+
+                var peopleRemoved = new List<int>();
+                var groupTypesRemoved = new List<int>();
+                var groupsRemoved = new List<int>();
+                var locationsRemoved = new List<int>();
+
+                foreach ( var family in checkInState.CheckIn.Families.ToList() )
+                {
+                    foreach ( var person in family.People.ToList() )
+                    {
+                        foreach ( var groupType in person.GroupTypes.ToList() )
+                        {
+                            foreach ( var group in groupType.Groups.ToList() )
+                            {
+                                foreach ( var location in group.Locations.ToList() )
+                                {
+                                    if ( location.Schedules.Count == 0 || !location.Schedules.Any( s => !s.ExcludedByFilter ) )
+                                    {
+                                        locationsRemoved.Add( location.Location.Id );
+                                    }
+                                }
+                                if ( group.Locations.Count == 0 || !group.Locations.Any( gl => !locationsRemoved.Contains( gl.Location.Id ) ) || !group.Locations.Any( l => !l.ExcludedByFilter ) )
+                                {
+                                    groupsRemoved.Add( group.Group.Id );
+                                }
+                            }
+                            if ( groupType.Groups.Count == 0 || !groupType.Groups.Any( g => !groupsRemoved.Contains( g.Group.Id ) ) || !groupType.Groups.Any( g => !g.ExcludedByFilter ) )
+                            {
+                                groupTypesRemoved.Add( groupType.GroupType.Id );
+                            }
+                        }
+                        if ( person.GroupTypes.Count == 0 || person.GroupTypes.All( gt => groupTypesRemoved.Contains( gt.GroupType.Id ) ) || person.GroupTypes.All( t => t.ExcludedByFilter ) )
+                        {
+                            peopleRemoved.Add( person.Person.Id );
+                        }
+                    }
+                }
+
+                var noMatchingFamilies =
+                (
+                    checkInState.CheckIn.Families.All( f => f.People.Count == 0 || !f.People.Any( fp => !peopleRemoved.Contains( fp.Person.Id ) ) ) &&
+                    checkInState.CheckIn.Families.All( f => f.Action == CheckinAction.CheckIn ) // not sure this is needed
+                )
+                &&
+                (
+                    !checkInState.AllowCheckout ||
+                    (
+                        checkInState.AllowCheckout &&
+                        checkInState.CheckIn.Families.All( f => f.CheckOutPeople.Count == 0 || !f.CheckOutPeople.Any( fp => !peopleRemoved.Contains( fp.Person.Id ) ) )
+                    )
+                );
+                if ( noMatchingFamilies )
+                {
+                    var mergeFields = new Dictionary<string, object>();
+                    mergeFields.Add( "CurrentFamily", checkInState.CheckIn.CurrentFamily );
+                    mergeFields.Add( "Families", checkInState.CheckIn.Families );
+                    mergeFields.Add( "CurrentPerson", checkInState.CheckIn.CurrentPerson );
+                    mergeFields.Add( "SearchValue", checkInState.CheckIn.SearchValue );
+                    mergeFields.Add( "Messages", checkInState.Messages );
+                    mergeFields.Add( "RemovedPeople", peopleRemoved );
+                    mergeFields.Add( "RemovedGroupTypes", groupTypesRemoved );
+                    mergeFields.Add( "RemovedGroups", groupsRemoved );
+                    mergeFields.Add( "RemovedLocations", locationsRemoved );
+
+                    checkInState.Messages.Add( new CheckInMessage { MessageText = errorMessageTemplate.ResolveMergeFields( mergeFields, checkInState.CheckIn.CurrentPerson?.Person ), MessageType = MessageType.Warning } );
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/rocks.kfs.Workflow.Action.CheckIn/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Workflow.Action.CheckIn/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.Workflow.Action.CheckIn" )]
 [assembly: AssemblyProduct( "rocks.kfs.Workflow.Action.CheckIn" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2019" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.0.*" )]
+[assembly: AssemblyVersion( "2.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Workflow.Action.CheckIn/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Workflow.Action.CheckIn/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2021 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.5.*" )]
+[assembly: AssemblyVersion( "2.6.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Workflow.Action.CheckIn/rocks.kfs.Workflow.Action.CheckIn.csproj
+++ b/rocks.kfs.Workflow.Action.CheckIn/rocks.kfs.Workflow.Action.CheckIn.csproj
@@ -60,6 +60,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CheckForEmptyCheckin.cs" />
     <Compile Include="LoadBalanceLocations.cs" />
     <Compile Include="Migrations\002_AddOccurrenceClosedAttribute.cs" />
     <Compile Include="Migrations\001_AddLoadBalanceAttribute.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Created CheckForEmptyCheckin workflow action, that will attach messages to the check-in state to be read by a block during check-in.

**New Settings:**

- _Error Message Template_, This will be the error message that gets attached to the check-in state for this instance of the action. Logic can be applied based on 'RemovedPeople', 'RemovedGroupTypes', 'RemovedGroups' and 'RemovedLocations'. If you return an empty message it will not display for this instance in our block.
- _Always Log Lava_, Enable this if you want the message to be created no matter the result. By default it will only create a message if all people will be removed, such as when your whole family is already checked in or the classrooms are full.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added new Workflow action "Check for Empty Check-in"

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington and Venture

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/139153208-0be287f7-d84e-40d0-867c-28b1fe9719d4.png)

Two examples of customized messages:    
<img width="850" alt="Screenshot 2021-11-05 103221" src="https://user-images.githubusercontent.com/2990519/140549241-57aec858-3a94-4a5e-8a48-dfbd8f32958b.png">

<img width="844" alt="Screenshot 2021-11-05 103517" src="https://user-images.githubusercontent.com/2990519/140549244-3f5919bd-cd16-4149-bbc8-a63d3e9f139e.png">


---------

### Change Log

##### What files does it affect?

- rocks.kfs.Workflow.Action.CheckIn/CheckForEmptyCheckin.cs
- rocks.kfs.Workflow.Action.CheckIn/Properties/AssemblyInfo.cs
- rocks.kfs.Workflow.Action.CheckIn/rocks.kfs.Workflow.Action.CheckIn.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, though the block is recommended, otherwise it doesn't display anywhere. https://github.com/KingdomFirst/RockBlocks/pull/81
