### PR TITLE
Add support for Other Receipts to Intacct api model

### DIFF
--- a/rocks.kfs.Intacct/Enums/PaymentMethod.cs
+++ b/rocks.kfs.Intacct/Enums/PaymentMethod.cs
@@ -15,17 +15,22 @@
 // </copyright>
 //
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace rocks.kfs.Intacct.Enums
 {
     public enum PaymentMethod
     {
+        [Display( Name = "Check" )]
         [Description( "Printed Check" )]
         PrintedCheck,
+        [Display( Name = "Cash" )]
         [Description( "Cash" )]
         Cash,
+        [Display( Name = "Record Transfer" )]
         [Description( "EFT" )]
         EFT,
+        [Display( Name = "Credit Card" )]
         [Description( "Credit Card" )]
         CreditCard
     }

--- a/rocks.kfs.Intacct/Enums/PaymentMethod.cs
+++ b/rocks.kfs.Intacct/Enums/PaymentMethod.cs
@@ -1,0 +1,32 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.ComponentModel;
+
+namespace rocks.kfs.Intacct.Enums
+{
+    public enum PaymentMethod
+    {
+        [Description( "Printed Check" )]
+        PrintedCheck,
+        [Description( "Cash" )]
+        Cash,
+        [Description( "EFT" )]
+        EFT,
+        [Description( "Credit Card" )]
+        CreditCard
+    }
+}

--- a/rocks.kfs.Intacct/IntacctCheckingAccountList.cs
+++ b/rocks.kfs.Intacct/IntacctCheckingAccountList.cs
@@ -35,7 +35,7 @@ namespace rocks.kfs.Intacct
         /// </summary>
         /// <param name="AuthCreds">The IntacctAuth object with authentication. <see cref="IntacctAuth"/></param>
         /// <returns>Returns the XML needed to request a list of Bank Accounts.</returns>
-        public XmlDocument GetBankAccountsXML( IntacctAuth AuthCreds, int batchId, ref string debugLava, string DescriptionLava = "", List<string> fields = null )
+        public XmlDocument GetBankAccountsXML( IntacctAuth AuthCreds, int batchId, List<string> fields = null )
         {
             var doc = new XmlDocument();
             using ( var writer = doc.CreateNavigator().AppendChild() )

--- a/rocks.kfs.Intacct/IntacctCheckingAccountList.cs
+++ b/rocks.kfs.Intacct/IntacctCheckingAccountList.cs
@@ -1,0 +1,99 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Xml;
+
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using KFSConst = rocks.kfs.Intacct.SystemGuid;
+
+namespace rocks.kfs.Intacct
+{
+    public class IntacctCheckingAccountList
+    {
+        /// <summary>
+        /// Creates the XML to submit to Intacct to capture a list of Bank Accounts
+        /// </summary>
+        /// <param name="AuthCreds">The IntacctAuth object with authentication. <see cref="IntacctAuth"/></param>
+        /// <returns>Returns the XML needed to request a list of Bank Accounts.</returns>
+        public XmlDocument GetBankAccountsXML( IntacctAuth AuthCreds, int batchId, ref string debugLava, string DescriptionLava = "", List<string> fields = null )
+        {
+            var doc = new XmlDocument();
+            using ( var writer = doc.CreateNavigator().AppendChild() )
+            {
+                writer.WriteStartDocument();
+                writer.WriteStartElement( "request" );
+                writer.WriteStartElement( "control" );
+                writer.WriteElementString( "senderid", AuthCreds.SenderId );
+                writer.WriteElementString( "password", AuthCreds.SenderPassword );
+                writer.WriteElementString( "controlid", $"RequestControl_{batchId}" );
+                writer.WriteElementString( "uniqueid", "false" );
+                writer.WriteElementString( "dtdversion", "3.0" );
+                writer.WriteElementString( "includewhitespace", "false" );
+                writer.WriteEndElement();  // close control
+                writer.WriteStartElement( "operation" );
+                writer.WriteStartElement( "authentication" );
+                writer.WriteStartElement( "login" );
+                writer.WriteElementString( "userid", AuthCreds.UserId );
+                writer.WriteElementString( "companyid", AuthCreds.CompanyId );
+                writer.WriteElementString( "password", AuthCreds.UserPassword );
+                if ( !string.IsNullOrWhiteSpace( AuthCreds.LocationId ) )
+                {
+                    writer.WriteElementString( "locationid", AuthCreds.LocationId );
+                }
+                writer.WriteEndElement();  // close login
+                writer.WriteEndElement();  // close authentication
+                writer.WriteStartElement( "content" );
+                writer.WriteStartElement( "function" );
+                writer.WriteAttributeString( "controlid", $"Batch_{batchId}" );
+                writer.WriteStartElement( "readByQuery" );
+                writer.WriteElementString( "object", "CHECKINGACCOUNT" );
+                if ( fields == null )
+                {
+                    writer.WriteElementString( "fields", "*" );
+                }
+                else
+                {
+                    var fieldsString = string.Join( ",", fields.Select( f => f.Trim() ) );
+                    writer.WriteElementString( "fields", fieldsString );
+                }
+                writer.WriteElementString( "query", null );
+                writer.WriteEndElement();  // close readByQuery
+                writer.WriteEndElement();  // close function
+                writer.WriteEndElement();  // close content
+                writer.WriteEndElement();  // close operation
+                writer.WriteEndElement();  // close request
+                writer.WriteEndDocument(); // close document
+            }
+
+            XmlDeclaration xmldecl;
+            xmldecl = doc.CreateXmlDeclaration( "1.0", null, null );
+            xmldecl.Encoding = "UTF-8";
+            xmldecl.Standalone = "yes";
+
+            XmlElement root = doc.DocumentElement;
+            doc.InsertBefore( xmldecl, root );
+
+            return doc;
+        }
+    }
+}

--- a/rocks.kfs.Intacct/IntacctEndpoint.cs
+++ b/rocks.kfs.Intacct/IntacctEndpoint.cs
@@ -213,7 +213,7 @@ namespace rocks.kfs.Intacct
                                             BankAccountId = xAcctXml.Elements( "BANKACCOUNTID" ).FirstOrDefault().Value ?? null,
                                             BankAcountNo = xAcctXml.Elements( "BANKACCOUNTNO" ).FirstOrDefault().Value ?? null,
                                             GLAccountNo = xAcctXml.Elements( "GLACCOUNTNO" ).FirstOrDefault().Value ?? null,
-                                            BankName = xAcctXml.Elements( "BANKNAME" ).FirstOrDefault().Value ?? null,
+                                            BankName = xAcctXml.Elements( "BANKNAME" ).FirstOrDefault().Value ?? null
                                         };
                                         bankAccountList.Add( bankAccount );
                                     }

--- a/rocks.kfs.Intacct/IntacctEndpoint.cs
+++ b/rocks.kfs.Intacct/IntacctEndpoint.cs
@@ -184,13 +184,23 @@ namespace rocks.kfs.Intacct
                                 {
                                     foreach ( var xAcctXml in xCheckingAccountsXml )
                                     {
-                                        var bankAccount = new CheckingAccount
+                                        var bankAccount = new CheckingAccount();
+                                        if ( xAcctXml.Elements( "BANKACCOUNTID" ).FirstOrDefault() != null )
                                         {
-                                            BankAccountId = xAcctXml.Elements( "BANKACCOUNTID" ).FirstOrDefault().Value ?? null,
-                                            BankAcountNo = xAcctXml.Elements( "BANKACCOUNTNO" ).FirstOrDefault().Value ?? null,
-                                            GLAccountNo = xAcctXml.Elements( "GLACCOUNTNO" ).FirstOrDefault().Value ?? null,
-                                            BankName = xAcctXml.Elements( "BANKNAME" ).FirstOrDefault().Value ?? null
-                                        };
+                                            bankAccount.BankAccountId = xAcctXml.Elements( "BANKACCOUNTID" ).FirstOrDefault().Value;
+                                        }
+                                        if ( xAcctXml.Elements( "BANKACCOUNTNO" ).FirstOrDefault() != null )
+                                        {
+                                            bankAccount.BankAcountNo = xAcctXml.Elements( "BANKACCOUNTNO" ).FirstOrDefault().Value;
+                                        }
+                                        if ( xAcctXml.Elements( "GLACCOUNTNO" ).FirstOrDefault() != null )
+                                        {
+                                            bankAccount.GLAccountNo = xAcctXml.Elements( "GLACCOUNTNO" ).FirstOrDefault().Value;
+                                        }
+                                        if ( xAcctXml.Elements( "BANKNAME" ).FirstOrDefault() != null )
+                                        {
+                                            bankAccount.BankName = xAcctXml.Elements( "BANKNAME" ).FirstOrDefault().Value;
+                                        }
                                         bankAccountList.Add( bankAccount );
                                     }
                                 }

--- a/rocks.kfs.Intacct/IntacctEndpoint.cs
+++ b/rocks.kfs.Intacct/IntacctEndpoint.cs
@@ -159,34 +159,10 @@ namespace rocks.kfs.Intacct
             return false;
         }
 
-        public List<CheckingAccount> ParseListCheckingAccountsResponse( XmlDocument xmlDocument, int BatchId, bool Log = false )
+        public List<CheckingAccount> ParseListCheckingAccountsResponse( XmlDocument xmlDocument, int BatchId )
         {
             var bankAccountList = new List<CheckingAccount>();
             var resultX = XDocument.Load( new XmlNodeReader( xmlDocument ) );
-
-            if ( Log )
-            {
-                var financialBatch = new FinancialBatchService( new RockContext() ).Get( BatchId );
-                var changes = new History.HistoryChangeList();
-                var oldValue = string.Empty;
-                var newValue = resultX.ToString();
-
-                History.EvaluateChange( changes, "Intacct Response", oldValue, newValue );
-
-                var rockContext = new RockContext();
-                rockContext.WrapTransaction( () =>
-                {
-                    if ( changes.Any() )
-                    {
-                        HistoryService.SaveChanges(
-                            rockContext,
-                            typeof( FinancialBatch ),
-                            Rock.SystemGuid.Category.HISTORY_FINANCIAL_BATCH.AsGuid(),
-                            BatchId,
-                            changes );
-                    }
-                } );
-            }
 
             var xResponseXml = resultX.Elements( "response" ).FirstOrDefault();
             if ( xResponseXml != null )

--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -218,6 +218,7 @@ namespace rocks.kfs.Intacct
             {
                 var account = new FinancialAccountService( rockContext ).Get( summary.FinancialAccountId );
                 var customDimensionValues = new Dictionary<string, dynamic>();
+                account.LoadAttributes();
                 var mergeFieldObjects = new MergeFieldObjects
                 {
                     Account = account,

--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -24,6 +24,7 @@ using Rock;
 using Rock.Data;
 using Rock.Model;
 using Rock.Web.Cache;
+using rocks.kfs.Intacct.Utils;
 using KFSConst = rocks.kfs.Intacct.SystemGuid;
 
 namespace rocks.kfs.Intacct
@@ -204,140 +205,29 @@ namespace rocks.kfs.Intacct
             //
             // Group/Sum Transactions by Account and Project since Project can come from Account or Transaction Details
             //
-            var batchTransactions = new List<GLTransaction>();
-            var registrationLinks = new List<RegistrationInstance>();
-            var groupMemberLinks = new List<GroupMember>();
-            foreach ( var transaction in financialBatch.Transactions )
-            {
-                transaction.LoadAttributes();
-                var gateway = transaction.FinancialGateway;
-                var gatewayDefaultFeeAccount = string.Empty;
-                var processTransactionFees = 0;
-                if ( gateway != null )
-                {
-                    gateway.LoadAttributes();
-                    gatewayDefaultFeeAccount = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.DEFAULTFEEACCOUNTNO" );
-                    var gatewayFeeProcessing = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.FEEPROCESSING" ).AsIntegerOrNull();
-                    if ( gatewayFeeProcessing != null )
-                    {
-                        processTransactionFees = gatewayFeeProcessing.Value;
-                    }
-                }
-
-                foreach ( var transactionDetail in transaction.TransactionDetails )
-                {
-                    transactionDetail.LoadAttributes();
-                    transactionDetail.Account.LoadAttributes();
-
-                    var detailProject = transactionDetail.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
-                    var accountProject = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
-                    var transactionFeeAccount = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.FEEACCOUNTNO" );
-
-                    if ( string.IsNullOrWhiteSpace( transactionFeeAccount ) )
-                    {
-                        transactionFeeAccount = gatewayDefaultFeeAccount;
-                    }
-
-                    var projectCode = string.Empty;
-                    if ( detailProject != null )
-                    {
-                        projectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
-                    }
-                    else if ( accountProject != null )
-                    {
-                        projectCode = DefinedValueCache.Get( ( Guid ) accountProject ).Value;
-                    }
-
-                    if ( transactionDetail.EntityTypeId.HasValue )
-                    {
-                        var registrationEntityType = EntityTypeCache.Get( typeof( Rock.Model.Registration ) );
-                        var groupMemberEntityType = EntityTypeCache.Get( typeof( Rock.Model.GroupMember ) );
-
-                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == registrationEntityType.Id )
-                        {
-                            foreach ( var registration in new RegistrationService( rockContext )
-                                .Queryable().AsNoTracking()
-                                .Where( r =>
-                                    r.RegistrationInstance != null &&
-                                    r.RegistrationInstance.RegistrationTemplate != null &&
-                                    r.Id == transactionDetail.EntityId ) )
-                            {
-                                registrationLinks.Add( registration.RegistrationInstance );
-                            }
-                        }
-                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == groupMemberEntityType.Id )
-                        {
-                            foreach ( var groupMember in new GroupMemberService( rockContext )
-                                .Queryable().AsNoTracking()
-                                .Where( gm =>
-                                    gm.Group != null &&
-                                    gm.Id == transactionDetail.EntityId ) )
-                            {
-                                groupMemberLinks.Add( groupMember );
-                            }
-                        }
-                    }
-
-                    var transactionItem = new GLTransaction()
-                    {
-                        Amount = transactionDetail.Amount,
-                        FinancialAccountId = transactionDetail.AccountId,
-                        Project = projectCode,
-                        TransactionFeeAmount = transactionDetail.FeeAmount != null && transactionDetail.FeeAmount.Value > 0 ? transactionDetail.FeeAmount.Value : 0.0M,
-                        TransactionFeeAccount = transactionFeeAccount,
-                        ProcessTransactionFees = processTransactionFees
-                    };
-
-                    batchTransactions.Add( transactionItem );
-                }
-            }
-
-            var batchTransactionsSummary = batchTransactions
-                .GroupBy( d => new { d.FinancialAccountId, d.Project, d.TransactionFeeAccount, d.ProcessTransactionFees } )
-                .Select( s => new GLTransaction
-                {
-                    FinancialAccountId = s.Key.FinancialAccountId,
-                    Project = s.Key.Project,
-                    Amount = s.Sum( f => ( decimal? ) f.Amount ) ?? 0.0M,
-                    TransactionFeeAmount = s.Sum( f => ( decimal? ) f.TransactionFeeAmount ) ?? 0.0M,
-                    TransactionFeeAccount = s.Key.TransactionFeeAccount,
-                    ProcessTransactionFees = s.Key.ProcessTransactionFees
-                } )
-                .ToList();
+            List<RegistrationInstance> registrationLinks;
+            List<GroupMember> groupMemberLinks;
+            var batchTransactionsSummary = TransactionHelpers.GetTransactionSummary( financialBatch, rockContext, out registrationLinks, out groupMemberLinks );
 
             //
             // Get the Dimensions from the Account since the Transaction Details have been Grouped already
             //
-            var customDimensions = GetCustomDimensions();
+            var customDimensions = TransactionHelpers.GetCustomDimensions();
             var batchSummary = new List<GLBatchTotals>();
             foreach ( var summary in batchTransactionsSummary )
             {
                 var account = new FinancialAccountService( rockContext ).Get( summary.FinancialAccountId );
                 var customDimensionValues = new Dictionary<string, dynamic>();
-                var mergeFields = new Dictionary<string, object>();
-                account.LoadAttributes();
-
-
-                if ( customDimensions.Count > 0 )
+                var mergeFieldObjects = new MergeFieldObjects
                 {
-                    foreach ( var rockKey in customDimensions )
-                    {
-                        var dimension = rockKey.Split( '.' ).Last();
-                        customDimensionValues.Add( dimension, account.GetAttributeValue( rockKey ) );
-                    }
-                }
-
-                mergeFields.Add( "Account", account );
-                mergeFields.Add( "Summary", summary );
-                mergeFields.Add( "Batch", financialBatch );
-                mergeFields.Add( "Registrations", registrationLinks );
-                mergeFields.Add( "GroupMembers", groupMemberLinks );
-                mergeFields.Add( "CustomDimensions", customDimensionValues );
-
-                if ( debugLava.Length < 6 && debugLava.AsBoolean() )
-                {
-                    debugLava = mergeFields.lavaDebugInfo();
-                }
+                    Account = account,
+                    Batch = financialBatch,
+                    Registrations = registrationLinks,
+                    GroupMembers = groupMemberLinks,
+                    Summary = summary,
+                    CustomDimensions = customDimensions
+                };
+                Dictionary<string, object> mergeFields = TransactionHelpers.GetMergeFieldsAndDimensions(  ref debugLava, customDimensionValues, mergeFieldObjects );
 
                 var batchSummaryItem = new GLBatchTotals()
                 {
@@ -359,38 +249,6 @@ namespace rocks.kfs.Intacct
             }
 
             return GenerateLineItems( batchSummary );
-        }
-
-        private List<string> GetCustomDimensions()
-        {
-            var knownDimensions = new List<string>();
-            knownDimensions.Add( "rocks.kfs.Intacct.ACCOUNTNO" );
-            knownDimensions.Add( "rocks.kfs.Intacct.DEBITACCOUNTNO" );
-            knownDimensions.Add( "rocks.kfs.Intacct.FEEACCOUNTNO" );
-            knownDimensions.Add( "rocks.kfs.Intacct.DEFAULTFEEACCOUNTNO" );
-            knownDimensions.Add( "rocks.kfs.Intacct.FEEPROCESSING" );
-            knownDimensions.Add( "rocks.kfs.Intacct.CLASSID" );
-            knownDimensions.Add( "rocks.kfs.Intacct.DEPARTMENT" );
-            knownDimensions.Add( "rocks.kfs.Intacct.LOCATION" );
-            knownDimensions.Add( "rocks.kfs.Intacct.PROJECTID" );
-
-            var rockContext = new RockContext();
-            var accountCategoryId = new CategoryService( rockContext ).Queryable().FirstOrDefault( c => c.Guid.Equals( new System.Guid( KFSConst.Attribute.FINANCIAL_ACCOUNT_ATTRIBUTE_CATEGORY ) ) ).Id;
-            var gatewayCategoryId = new CategoryService( rockContext ).Queryable().FirstOrDefault( c => c.Guid.Equals( new System.Guid( KFSConst.Attribute.FINANCIAL_GATEWAY_ATTRIBUTE_CATEGORY ) ) ).Id;
-            var attributeService = new AttributeService( rockContext );
-            var accountAttributes = attributeService.Queryable().Where( a => a.Categories.Select( c => c.Id ).Contains( accountCategoryId ) ).ToList();
-
-            var customDimensions = new List<string>();
-
-            foreach ( var attribute in accountAttributes )
-            {
-                if ( !knownDimensions.Contains( attribute.Key ) )
-                {
-                    customDimensions.Add( attribute.Key );
-                }
-            }
-
-            return customDimensions;
         }
 
         private List<JournalEntryLine> GenerateLineItems( List<GLBatchTotals> transactionItems )

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -367,20 +367,6 @@ namespace rocks.kfs.Intacct
         #endregion
     }
 
-    public class OtherReceiptSummaryTotals
-    {
-        public decimal Amount;
-        public string CreditAccount;
-        public string BankAccount;
-        public string Class;
-        public string Department;
-        public string Location;
-        public string Project;
-        public string Description;
-        public Dictionary<string, dynamic> CustomDimensions;
-        public int ProcessTransactionFees;
-    }
-
     public class CheckingAccount
     {
         public string BankAccountId { get; set; }

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using Rock;
 using Rock.Data;
+using rocks.kfs.Intacct.Enums;
 
 namespace rocks.kfs.Intacct
 {
@@ -74,6 +75,49 @@ namespace rocks.kfs.Intacct
         public string ClassId;
         public string ContractId;
         public string WarehouseId;
+    }
+
+    public class OtherReceipt
+    {
+        public DateTime PaymentDate;
+        public string Payer; // Incorrectly named "payee" in API.
+        public DateTime ReceivedDate;
+        public PaymentMethod PaymentMethod;
+        public string UnDepGLAccountNo;
+        public string BankAccountId;
+        public DateTime? DepositDate;
+        public string RefId;
+        public string Description;
+        public string SupDocId;
+        public string Currency;
+        public DateTime? ExchRateDate;
+        public string ExchRateType;
+        public decimal? ExchRate;
+        public Dictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
+        public bool? InclusiveTax;
+        public string TaxSolutionId;
+        public List<ReceiptLineItem> ReceiptItems;
+
+    }
+
+    public class ReceiptLineItem
+    {
+        public string GlAccountNo;
+        public string AccountLabel;
+        public decimal Amount;
+        public string Memo;
+        public string LocationId;
+        public string DepartmentId;
+        public Dictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
+        public string ProjectId;
+        public string TaskId;
+        public string CostTypeId;
+        public string CustomerId;
+        public string VendorId;
+        public string EmployeeId;
+        public string ItemId;
+        public string ClassId;
+        public decimal TotalTrxAmount;
     }
 
     public class GLTransaction : Rock.Lava.ILiquidizable
@@ -201,5 +245,147 @@ namespace rocks.kfs.Intacct
         public string Description;
         public Dictionary<string, dynamic> CustomDimensions;
         public int ProcessTransactionFees;
+    }
+
+    public class OtherReceiptTransaction : Rock.Lava.ILiquidizable
+    {
+        [LavaInclude]
+        public int? TransactionId;
+
+        [LavaInclude]
+        public string Payer;
+
+        [LavaInclude]
+        public decimal Amount;
+
+        [LavaInclude]
+        public int FinancialAccountId;
+
+        [LavaInclude]
+        public string Project;
+
+        [LavaInclude]
+        public DateTime PaymentDate;
+
+        [LavaInclude]
+        public decimal TransactionFeeAmount;
+
+        [LavaInclude]
+        public string TransactionFeeAccount;
+
+        [LavaInclude]
+        public int ProcessTransactionFees;
+
+        #region ILiquidizable
+
+        /// <summary>
+        /// Creates a DotLiquid compatible dictionary that represents the current entity object. 
+        /// </summary>
+        /// <returns>DotLiquid compatible dictionary.</returns>
+        public object ToLiquid()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the available keys (for debugging info).
+        /// </summary>
+        /// <value>
+        /// The available keys.
+        /// </value>
+        [LavaIgnore]
+        public virtual List<string> AvailableKeys
+        {
+            get
+            {
+                var availableKeys = new List<string>();
+
+                foreach ( var propInfo in GetType().GetProperties() )
+                {
+                    availableKeys.Add( propInfo.Name );
+                }
+
+                return availableKeys;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="System.Object"/> with the specified key.
+        /// </summary>
+        /// <value>
+        /// The <see cref="System.Object"/>.
+        /// </value>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        [LavaIgnore]
+        public virtual object this[object key]
+        {
+            get
+            {
+                string propertyKey = key.ToStringSafe();
+                var propInfo = GetType().GetProperty( propertyKey );
+
+                try
+                {
+                    object propValue = null;
+                    if ( propInfo != null )
+                    {
+                        propValue = propInfo.GetValue( this, null );
+                    }
+
+                    if ( propValue is Guid )
+                    {
+                        return ( ( Guid ) propValue ).ToString();
+                    }
+                    else
+                    {
+                        return propValue;
+                    }
+                }
+                catch
+                {
+                    // intentionally ignore
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the specified key contains key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        public virtual bool ContainsKey( object key )
+        {
+            string propertyKey = key.ToStringSafe();
+            var propInfo = GetType().GetProperty( propertyKey );
+
+            return propInfo != null;
+        }
+
+        #endregion
+    }
+
+    public class OtherReceiptSummaryTotals
+    {
+        public decimal Amount;
+        public string CreditAccount;
+        public string BankAccount;
+        public string Class;
+        public string Department;
+        public string Location;
+        public string Project;
+        public string Description;
+        public Dictionary<string, dynamic> CustomDimensions;
+        public int ProcessTransactionFees;
+    }
+
+    public class CheckingAccount
+    {
+        public string BankAccountId { get; set; }
+        public string BankAcountNo { get; set; }
+        public string GLAccountNo { get; set; }
+        public string BankName { get; set; }
     }
 }

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -140,6 +140,9 @@ namespace rocks.kfs.Intacct
         [LavaInclude]
         public int ProcessTransactionFees;
 
+        [LavaInclude]
+        public string Payer;
+
         #region ILiquidizable
 
         /// <summary>
@@ -245,126 +248,6 @@ namespace rocks.kfs.Intacct
         public string Description;
         public Dictionary<string, dynamic> CustomDimensions;
         public int ProcessTransactionFees;
-    }
-
-    public class OtherReceiptTransaction : Rock.Lava.ILiquidizable
-    {
-        [LavaInclude]
-        public int? TransactionId;
-
-        [LavaInclude]
-        public string Payer;
-
-        [LavaInclude]
-        public decimal Amount;
-
-        [LavaInclude]
-        public int FinancialAccountId;
-
-        [LavaInclude]
-        public string Project;
-
-        [LavaInclude]
-        public DateTime PaymentDate;
-
-        [LavaInclude]
-        public decimal TransactionFeeAmount;
-
-        [LavaInclude]
-        public string TransactionFeeAccount;
-
-        [LavaInclude]
-        public int ProcessTransactionFees;
-
-        #region ILiquidizable
-
-        /// <summary>
-        /// Creates a DotLiquid compatible dictionary that represents the current entity object. 
-        /// </summary>
-        /// <returns>DotLiquid compatible dictionary.</returns>
-        public object ToLiquid()
-        {
-            return this;
-        }
-
-        /// <summary>
-        /// Gets the available keys (for debugging info).
-        /// </summary>
-        /// <value>
-        /// The available keys.
-        /// </value>
-        [LavaIgnore]
-        public virtual List<string> AvailableKeys
-        {
-            get
-            {
-                var availableKeys = new List<string>();
-
-                foreach ( var propInfo in GetType().GetProperties() )
-                {
-                    availableKeys.Add( propInfo.Name );
-                }
-
-                return availableKeys;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="System.Object"/> with the specified key.
-        /// </summary>
-        /// <value>
-        /// The <see cref="System.Object"/>.
-        /// </value>
-        /// <param name="key">The key.</param>
-        /// <returns></returns>
-        [LavaIgnore]
-        public virtual object this[object key]
-        {
-            get
-            {
-                string propertyKey = key.ToStringSafe();
-                var propInfo = GetType().GetProperty( propertyKey );
-
-                try
-                {
-                    object propValue = null;
-                    if ( propInfo != null )
-                    {
-                        propValue = propInfo.GetValue( this, null );
-                    }
-
-                    if ( propValue is Guid )
-                    {
-                        return ( ( Guid ) propValue ).ToString();
-                    }
-                    else
-                    {
-                        return propValue;
-                    }
-                }
-                catch
-                {
-                    // intentionally ignore
-                }
-
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the specified key contains key.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <returns></returns>
-        public virtual bool ContainsKey( object key )
-        {
-            string propertyKey = key.ToStringSafe();
-            var propInfo = GetType().GetProperty( propertyKey );
-
-            return propInfo != null;
-        }
-
-        #endregion
     }
 
     public class CheckingAccount

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -37,7 +37,7 @@ namespace rocks.kfs.Intacct
         /// <param name="AuthCreds">The IntacctAuth object with authentication. <see cref="IntacctAuth"/></param>
         /// <param name="Batch">The Rock FinancialBatch that a Journal Entry will be created from. <see cref="FinancialBatch"/></param>
         /// <returns>Returns the XML needed to create an Intacct Other Receipt.</returns>
-        public XmlDocument CreateOtherReceiptXML( IntacctAuth AuthCreds, int BatchId, ref string debugLava, PaymentMethod paymentMethod, string bankAccountId = null, string unDepGLAccountId = null , string DescriptionLava = "" )
+        public XmlDocument CreateOtherReceiptXML( IntacctAuth AuthCreds, int BatchId, ref string debugLava, PaymentMethod paymentMethod, string bankAccountId = null, string unDepGLAccountId = null, string DescriptionLava = "" )
         {
             var doc = new XmlDocument();
             var financialBatch = new FinancialBatchService( new RockContext() ).Get( BatchId );
@@ -313,7 +313,7 @@ namespace rocks.kfs.Intacct
                     batchTransactions.Add( transactionItem );
                 }
             }
-            
+
             var receiptTransactions = batchTransactions
             .GroupBy( d => new { d.FinancialAccountId, d.Project, d.TransactionFeeAccount, d.ProcessTransactionFees } )
             .Select( s => new OtherReceiptTransaction

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -100,6 +100,10 @@ namespace rocks.kfs.Intacct
                         {
                             writer.WriteElementString( "undepglaccountno", otherReceipt.UnDepGLAccountNo );
                         }
+                        if ( !string.IsNullOrWhiteSpace( otherReceipt.RefId ) )
+                        {
+                            writer.WriteElementString( "refid", otherReceipt.RefId );
+                        }
                         writer.WriteElementString( "description", otherReceipt.Description );
                         if ( !string.IsNullOrWhiteSpace( otherReceipt.Currency ) )
                         {
@@ -382,7 +386,7 @@ namespace rocks.kfs.Intacct
                     {
                         GlAccountNo = bTran.TransactionFeeAccount,
                         Amount = bTran.TransactionFeeAmount * -1,
-                        Memo = "Transaction Fee",
+                        Memo = "Transaction Fees",
                         LocationId = locationId,
                         DepartmentId = departmentId,
                         ProjectId = bTran.Project,

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -234,6 +234,7 @@ namespace rocks.kfs.Intacct
             {
                 var account = new FinancialAccountService( rockContext ).Get( bTran.FinancialAccountId );
                 var customDimensionValues = new Dictionary<string, dynamic>();
+                account.LoadAttributes();
                 var mergeFieldObjects = new MergeFieldObjects
                 {
                     Account = account,

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -356,6 +356,7 @@ namespace rocks.kfs.Intacct
                 mergeFields.Add( "Registrations", registrationLinks );
                 mergeFields.Add( "GroupMembers", groupMemberLinks );
                 mergeFields.Add( "CustomDimensions", customDimensionValues );
+                mergeFields.Add( "Summary", bTran );
 
                 if ( debugLava.Length < 6 && debugLava.AsBoolean() )
                 {
@@ -376,7 +377,8 @@ namespace rocks.kfs.Intacct
                     LocationId = locationId,
                     DepartmentId = departmentId,
                     ProjectId = bTran.Project,
-                    ClassId = classId
+                    ClassId = classId,
+                    CustomFields = customDimensionValues
                 };
                 otherReceipt.ReceiptItems.Add( receiptItem );
 

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -1,0 +1,344 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Xml;
+
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using rocks.kfs.Intacct.Enums;
+using KFSConst = rocks.kfs.Intacct.SystemGuid;
+
+namespace rocks.kfs.Intacct
+{
+    public class IntacctOtherReceipt
+    {
+        /// <summary>
+        /// Creates the XML to submit to Intacct for a new Other Receipt entry.
+        /// </summary>
+        /// <param name="AuthCreds">The IntacctAuth object with authentication. <see cref="IntacctAuth"/></param>
+        /// <param name="Batch">The Rock FinancialBatch that a Journal Entry will be created from. <see cref="FinancialBatch"/></param>
+        /// <returns>Returns the XML needed to create an Intacct Other Receipt.</returns>
+        public XmlDocument CreateOtherReceiptXML( IntacctAuth AuthCreds, int BatchId, ref string debugLava, PaymentMethod paymentMethod, string bankAccountId = null, string unDepGLAccountId = null , string DescriptionLava = "" )
+        {
+            var doc = new XmlDocument();
+            var financialBatch = new FinancialBatchService( new RockContext() ).Get( BatchId );
+
+            if ( financialBatch.Id > 0 )
+            {
+                var otherReceipt = BuildOtherReceipt( financialBatch, ref debugLava, paymentMethod, bankAccountId, DescriptionLava );
+                if ( otherReceipt.ReceiptItems.Any() )
+                {
+                    using ( var writer = doc.CreateNavigator().AppendChild() )
+                    {
+                        writer.WriteStartDocument();
+                        writer.WriteStartElement( "request" );
+                        writer.WriteStartElement( "control" );
+                        writer.WriteElementString( "senderid", AuthCreds.SenderId );
+                        writer.WriteElementString( "password", AuthCreds.SenderPassword );
+                        writer.WriteElementString( "controlid", $"RequestControl_{financialBatch.Id}" );
+                        writer.WriteElementString( "uniqueid", "false" );
+                        writer.WriteElementString( "dtdversion", "3.0" );
+                        writer.WriteElementString( "includewhitespace", "false" );
+                        writer.WriteEndElement();  // close control
+                        writer.WriteStartElement( "operation" );
+                        writer.WriteStartElement( "authentication" );
+                        writer.WriteStartElement( "login" );
+                        writer.WriteElementString( "userid", AuthCreds.UserId );
+                        writer.WriteElementString( "companyid", AuthCreds.CompanyId );
+                        writer.WriteElementString( "password", AuthCreds.UserPassword );
+                        if ( !string.IsNullOrWhiteSpace( AuthCreds.LocationId ) )
+                        {
+                            writer.WriteElementString( "locationid", AuthCreds.LocationId );
+                        }
+                        writer.WriteEndElement();  // close login
+                        writer.WriteEndElement();  // close authentication
+                        writer.WriteStartElement( "content" );
+                        writer.WriteStartElement( "function" );
+                        writer.WriteAttributeString( "controlid", $"Batch_{financialBatch.Id}" );
+                        writer.WriteStartElement( "record_otherreceipt" );
+                        writer.WriteStartElement( "paymentdate" );
+                        writer.WriteElementString( "year", otherReceipt.PaymentDate.Year.ToString() );
+                        writer.WriteElementString( "month", otherReceipt.PaymentDate.Month.ToString() );
+                        writer.WriteElementString( "day", otherReceipt.PaymentDate.Day.ToString() );
+                        writer.WriteEndElement();  // close paymentdate
+                        writer.WriteElementString( "payee", otherReceipt.Payer );
+                        writer.WriteStartElement( "receiveddate" );
+                        writer.WriteElementString( "year", otherReceipt.ReceivedDate.Year.ToString() );
+                        writer.WriteElementString( "month", otherReceipt.ReceivedDate.Month.ToString() );
+                        writer.WriteElementString( "day", otherReceipt.ReceivedDate.Day.ToString() );
+                        writer.WriteEndElement();  // close receiveddate
+                        writer.WriteElementString( "paymentmethod", otherReceipt.PaymentMethod.GetDescription() );
+                        if ( !string.IsNullOrWhiteSpace( otherReceipt.BankAccountId ) )
+                        {
+                            writer.WriteElementString( "bankaccountid", otherReceipt.BankAccountId );
+                        }
+                        else if ( !string.IsNullOrWhiteSpace( otherReceipt.UnDepGLAccountNo ) )
+                        {
+                            writer.WriteElementString( "undepglaccountn", otherReceipt.UnDepGLAccountNo );
+                        }
+                        writer.WriteStartElement( "depositdate" );
+                        writer.WriteElementString( "year", otherReceipt.DepositDate.Value.Year.ToString() );
+                        writer.WriteElementString( "month", otherReceipt.DepositDate.Value.Month.ToString() );
+                        writer.WriteElementString( "day", otherReceipt.DepositDate.Value.Day.ToString() );
+                        writer.WriteEndElement();  // close depositdate
+                        writer.WriteElementString( "refid", otherReceipt.RefId );
+                        writer.WriteElementString( "currency", otherReceipt.Currency ?? string.Empty );
+                        if ( otherReceipt.ExchRateDate.HasValue )
+                        {
+                            writer.WriteElementString( "exchratedate", ( ( DateTime ) otherReceipt.ExchRateDate ).ToShortDateString() );
+                        }
+                        if ( !string.IsNullOrWhiteSpace( otherReceipt.ExchRateType ) )
+                        {
+                            writer.WriteElementString( "exchratetype", otherReceipt.ExchRateType );
+                        }
+                        else if ( otherReceipt.ExchRate.HasValue )
+                        {
+                            writer.WriteElementString( "exchrate", otherReceipt.ExchRate.Value.ToString() );
+                        }
+                        else if ( !string.IsNullOrWhiteSpace( otherReceipt.Currency ) )
+                        {
+                            writer.WriteElementString( "exchratetype", otherReceipt.ExchRateType );
+                        }
+                        writer.WriteStartElement( "receiptitems" );
+
+                        // Add Receipt Items
+                        foreach ( var item in otherReceipt.ReceiptItems )
+                        {
+                            writer.WriteStartElement( "lineitem" );
+                            writer.WriteElementString( "glaccountno", item.GlAccountNo ?? string.Empty );
+                            writer.WriteElementString( "amount", item.Amount.ToString() );
+                            writer.WriteElementString( "memo", item.Memo ?? string.Empty );
+                            writer.WriteElementString( "locationid", item.LocationId ?? string.Empty );
+                            writer.WriteElementString( "departmentid", item.DepartmentId ?? string.Empty );
+                            writer.WriteElementString( "projectid", item.ProjectId ?? string.Empty );
+                            writer.WriteElementString( "taskid", item.TaskId ?? string.Empty );
+                            writer.WriteElementString( "customerid", item.CustomerId ?? string.Empty );
+                            writer.WriteElementString( "vendorid", item.VendorId ?? string.Empty );
+                            writer.WriteElementString( "employeeid", item.EmployeeId ?? string.Empty );
+                            writer.WriteElementString( "itemid", item.ItemId ?? string.Empty );
+                            writer.WriteElementString( "classid", item.ClassId ?? string.Empty );
+                            if ( item.CustomFields.Count > 0 )
+                            {
+                                foreach ( KeyValuePair<string, dynamic> customField in item.CustomFields )
+                                {
+                                    writer.WriteElementString( customField.Key, customField.Value ?? string.Empty );
+                                }
+                            }
+                            writer.WriteEndElement();  // close lineitem
+                        }
+
+                        writer.WriteEndElement();  // close receiptitems
+                        writer.WriteEndElement();  // close record_otherreceipt
+                        writer.WriteEndElement();  // close function
+                        writer.WriteEndElement();  // close content
+                        writer.WriteEndElement();  // close operation
+                        writer.WriteEndElement();  // close request
+                        writer.WriteEndDocument(); // close document
+                    }
+                }
+            }
+
+            XmlDeclaration xmldecl;
+            xmldecl = doc.CreateXmlDeclaration( "1.0", null, null );
+            xmldecl.Encoding = "UTF-8";
+            xmldecl.Standalone = "yes";
+
+            XmlElement root = doc.DocumentElement;
+            doc.InsertBefore( xmldecl, root );
+
+            return doc;
+        }
+
+        private OtherReceipt BuildOtherReceipt( FinancialBatch financialBatch, ref string debugLava, PaymentMethod paymentMethod, string bankAccountId = null, string unDepGLAccountId = null, string DescriptionLava = "" )
+        {
+            if ( string.IsNullOrWhiteSpace( DescriptionLava ) )
+            {
+                DescriptionLava = "{{ Batch.Id }}: {{ Batch.Name }}";
+            }
+
+            var rockContext = new RockContext();
+
+            var batchDate = financialBatch.BatchStartDateTime == null ? RockDateTime.Now : ( ( System.DateTime ) financialBatch.BatchStartDateTime );
+            var otherReceipt = new OtherReceipt
+            {
+                Payer = string.Format( "Rock Batch - {0} ({1})", financialBatch.Name, financialBatch.Id ),
+                PaymentDate = batchDate,
+                ReceivedDate = batchDate,
+                PaymentMethod = paymentMethod,
+                BankAccountId = bankAccountId,
+                UnDepGLAccountNo = unDepGLAccountId,
+                DepositDate = batchDate,
+                Description = string.Format( "Imported From Rock Batch {0} ({1})", financialBatch.Name, financialBatch.Id ),
+                RefId = financialBatch.Id.ToString()
+            };
+
+            //
+            // Group/Sum Transactions by Debit/Bank Account and Project since Project can come from Account or Transaction Details
+            //
+            var batchTransactions = new List<OtherReceiptTransaction>();
+            var registrationLinks = new List<RegistrationInstance>();
+            var groupMemberLinks = new List<GroupMember>();
+            foreach ( var transaction in financialBatch.Transactions )
+            {
+                transaction.LoadAttributes();
+                var gateway = transaction.FinancialGateway;
+                var gatewayDefaultFeeAccount = string.Empty;
+                var processTransactionFees = 0;
+                if ( gateway != null )
+                {
+                    gateway.LoadAttributes();
+                    gatewayDefaultFeeAccount = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.DEFAULTFEEACCOUNTNO" );
+                    var gatewayFeeProcessing = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.FEEPROCESSING" ).AsIntegerOrNull();
+                    if ( gatewayFeeProcessing != null )
+                    {
+                        processTransactionFees = gatewayFeeProcessing.Value;
+                    }
+                }
+
+                foreach ( var transactionDetail in transaction.TransactionDetails )
+                {
+                    transactionDetail.LoadAttributes();
+                    transactionDetail.Account.LoadAttributes();
+
+                    var detailProject = transactionDetail.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var accountProject = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var transactionFeeAccount = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.FEEACCOUNTNO" );
+
+                    if ( string.IsNullOrWhiteSpace( transactionFeeAccount ) )
+                    {
+                        transactionFeeAccount = gatewayDefaultFeeAccount;
+                    }
+
+                    var projectCode = string.Empty;
+                    if ( detailProject != null )
+                    {
+                        projectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
+                    }
+                    else if ( accountProject != null )
+                    {
+                        projectCode = DefinedValueCache.Get( ( Guid ) accountProject ).Value;
+                    }
+
+                    if ( transactionDetail.EntityTypeId.HasValue )
+                    {
+                        var registrationEntityType = EntityTypeCache.Get( typeof( Rock.Model.Registration ) );
+                        var groupMemberEntityType = EntityTypeCache.Get( typeof( Rock.Model.GroupMember ) );
+
+                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == registrationEntityType.Id )
+                        {
+                            foreach ( var registration in new RegistrationService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( r =>
+                                    r.RegistrationInstance != null &&
+                                    r.RegistrationInstance.RegistrationTemplate != null &&
+                                    r.Id == transactionDetail.EntityId ) )
+                            {
+                                registrationLinks.Add( registration.RegistrationInstance );
+                            }
+                        }
+                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == groupMemberEntityType.Id )
+                        {
+                            foreach ( var groupMember in new GroupMemberService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( gm =>
+                                    gm.Group != null &&
+                                    gm.Id == transactionDetail.EntityId ) )
+                            {
+                                groupMemberLinks.Add( groupMember );
+                            }
+                        }
+                    }
+
+                    var transactionItem = new OtherReceiptTransaction()
+                    {
+                        TransactionId = transactionDetail.TransactionId,
+                        Payer = transaction.AuthorizedPersonAlias.Person.FullName,
+                        Amount = transactionDetail.Amount,
+                        FinancialAccountId = transactionDetail.AccountId,
+                        Project = projectCode,
+                        PaymentDate = transaction.TransactionDateTime.Value,
+                        TransactionFeeAmount = transactionDetail.FeeAmount != null && transactionDetail.FeeAmount.Value > 0 ? transactionDetail.FeeAmount.Value : 0.0M,
+                        TransactionFeeAccount = transactionFeeAccount,
+                        ProcessTransactionFees = processTransactionFees
+                    };
+
+                    batchTransactions.Add( transactionItem );
+                }
+            }
+            
+            var receiptTransactions = batchTransactions
+            .GroupBy( d => new { d.FinancialAccountId, d.Project, d.TransactionFeeAccount, d.ProcessTransactionFees } )
+            .Select( s => new OtherReceiptTransaction
+            {
+                Payer = "Rock Import",
+                TransactionId = -1,
+                FinancialAccountId = s.Key.FinancialAccountId,
+                Project = s.Key.Project,
+                Amount = s.Sum( f => ( decimal? ) f.Amount ) ?? 0.0M,
+                TransactionFeeAmount = s.Sum( f => ( decimal? ) f.TransactionFeeAmount ) ?? 0.0M,
+                TransactionFeeAccount = s.Key.TransactionFeeAccount,
+                ProcessTransactionFees = s.Key.ProcessTransactionFees
+            } )
+            .ToList();
+
+            // Create Receipt Item for each entry within a grouping
+            foreach ( var bTran in receiptTransactions )
+            {
+                var account = new FinancialAccountService( rockContext ).Get( bTran.FinancialAccountId );
+                account.LoadAttributes();
+                var bankAccount = account.GetAttributeValue( "rocks.kfs.Intacct.DEBITACCOUNTNO" );
+                var glAccount = account.GetAttributeValue( "rocks.kfs.Intacct.ACCOUNTNO" );
+                var classId = account.GetAttributeValue( "rocks.kfs.Intacct.CLASSID" );
+                var departmentId = account.GetAttributeValue( "rocks.kfs.Intacct.DEPARTMENT" );
+                var locationId = account.GetAttributeValue( "rocks.kfs.Intacct.LOCATION" );
+                var receiptItem = new ReceiptLineItem
+                {
+                    GlAccountNo = glAccount,
+                    Amount = bTran.ProcessTransactionFees == 1 ? bTran.Amount - bTran.TransactionFeeAmount : bTran.Amount,
+                    Memo = "Imported from Rock",
+                    LocationId = locationId,
+                    DepartmentId = departmentId,
+                    ProjectId = bTran.Project,
+                    ClassId = classId
+                };
+                otherReceipt.ReceiptItems.Add( receiptItem );
+
+                if ( bTran.ProcessTransactionFees == 2 )
+                {
+                    var feeLineItem = new ReceiptLineItem
+                    {
+                        GlAccountNo = bTran.TransactionFeeAccount,
+                        Amount = bTran.TransactionFeeAmount * -1,
+                        Memo = "Transaction Fee",
+                        LocationId = locationId,
+                        DepartmentId = departmentId,
+                        ProjectId = bTran.Project,
+                        ClassId = classId
+                    };
+                    otherReceipt.ReceiptItems.Add( feeLineItem );
+                }
+            }
+
+            return otherReceipt;
+        }
+    }
+}

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.1.*" )]
+[assembly: AssemblyVersion( "2.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2021 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -1,0 +1,214 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using KFSConst = rocks.kfs.Intacct.SystemGuid;
+
+namespace rocks.kfs.Intacct.Utils
+{
+    public class TransactionHelpers
+    {
+        public static List<GLTransaction> GetTransactionSummary( FinancialBatch financialBatch, RockContext rockContext, out List<RegistrationInstance> registrationLinks, out List<GroupMember> groupMemberLinks )
+        {
+            //
+            // Group/Sum Transactions by Debit/Bank Account and Project since Project can come from Account or Transaction Details
+            //
+            var batchTransactions = new List<GLTransaction>();
+            registrationLinks = new List<RegistrationInstance>();
+            groupMemberLinks = new List<GroupMember>();
+            foreach ( var transaction in financialBatch.Transactions )
+            {
+                transaction.LoadAttributes();
+                var gateway = transaction.FinancialGateway;
+                var gatewayDefaultFeeAccount = string.Empty;
+                var processTransactionFees = 0;
+                if ( gateway != null )
+                {
+                    gateway.LoadAttributes();
+                    gatewayDefaultFeeAccount = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.DEFAULTFEEACCOUNTNO" );
+                    var gatewayFeeProcessing = transaction.FinancialGateway.GetAttributeValue( "rocks.kfs.Intacct.FEEPROCESSING" ).AsIntegerOrNull();
+                    if ( gatewayFeeProcessing != null )
+                    {
+                        processTransactionFees = gatewayFeeProcessing.Value;
+                    }
+                }
+
+                foreach ( var transactionDetail in transaction.TransactionDetails )
+                {
+                    transactionDetail.LoadAttributes();
+                    transactionDetail.Account.LoadAttributes();
+
+                    var detailProject = transactionDetail.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var accountProject = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var transactionFeeAccount = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.FEEACCOUNTNO" );
+
+                    if ( string.IsNullOrWhiteSpace( transactionFeeAccount ) )
+                    {
+                        transactionFeeAccount = gatewayDefaultFeeAccount;
+                    }
+
+                    var projectCode = string.Empty;
+                    if ( detailProject != null )
+                    {
+                        projectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
+                    }
+                    else if ( accountProject != null )
+                    {
+                        projectCode = DefinedValueCache.Get( ( Guid ) accountProject ).Value;
+                    }
+
+                    if ( transactionDetail.EntityTypeId.HasValue )
+                    {
+                        var registrationEntityType = EntityTypeCache.Get( typeof( Rock.Model.Registration ) );
+                        var groupMemberEntityType = EntityTypeCache.Get( typeof( Rock.Model.GroupMember ) );
+
+                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == registrationEntityType.Id )
+                        {
+                            foreach ( var registration in new RegistrationService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( r =>
+                                    r.RegistrationInstance != null &&
+                                    r.RegistrationInstance.RegistrationTemplate != null &&
+                                    r.Id == transactionDetail.EntityId ) )
+                            {
+                                registrationLinks.Add( registration.RegistrationInstance );
+                            }
+                        }
+                        if ( transactionDetail.EntityId.HasValue && transactionDetail.EntityTypeId == groupMemberEntityType.Id )
+                        {
+                            foreach ( var groupMember in new GroupMemberService( rockContext )
+                                .Queryable().AsNoTracking()
+                                .Where( gm =>
+                                    gm.Group != null &&
+                                    gm.Id == transactionDetail.EntityId ) )
+                            {
+                                groupMemberLinks.Add( groupMember );
+                            }
+                        }
+                    }
+
+                    var transactionItem = new GLTransaction()
+                    {
+                        Payer = transaction.AuthorizedPersonAlias.Person.FullName,
+                        Amount = transactionDetail.Amount,
+                        FinancialAccountId = transactionDetail.AccountId,
+                        Project = projectCode,
+                        TransactionFeeAmount = transactionDetail.FeeAmount != null && transactionDetail.FeeAmount.Value > 0 ? transactionDetail.FeeAmount.Value : 0.0M,
+                        TransactionFeeAccount = transactionFeeAccount,
+                        ProcessTransactionFees = processTransactionFees
+                    };
+
+                    batchTransactions.Add( transactionItem );
+                }
+            }
+
+            var batchTransactionList = batchTransactions
+            .GroupBy( d => new { d.FinancialAccountId, d.Project, d.TransactionFeeAccount, d.ProcessTransactionFees } )
+            .Select( s => new GLTransaction
+            {
+                Payer = "Rock Import",
+                FinancialAccountId = s.Key.FinancialAccountId,
+                Project = s.Key.Project,
+                Amount = s.Sum( f => ( decimal? ) f.Amount ) ?? 0.0M,
+                TransactionFeeAmount = s.Sum( f => ( decimal? ) f.TransactionFeeAmount ) ?? 0.0M,
+                TransactionFeeAccount = s.Key.TransactionFeeAccount,
+                ProcessTransactionFees = s.Key.ProcessTransactionFees
+            } )
+            .ToList();
+
+            return batchTransactionList;
+        }
+
+        public static List<string> GetCustomDimensions()
+        {
+            var knownDimensions = new List<string>();
+            knownDimensions.Add( "rocks.kfs.Intacct.ACCOUNTNO" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEBITACCOUNTNO" );
+            knownDimensions.Add( "rocks.kfs.Intacct.FEEACCOUNTNO" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEFAULTFEEACCOUNTNO" );
+            knownDimensions.Add( "rocks.kfs.Intacct.FEEPROCESSING" );
+            knownDimensions.Add( "rocks.kfs.Intacct.CLASSID" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEPARTMENT" );
+            knownDimensions.Add( "rocks.kfs.Intacct.LOCATION" );
+            knownDimensions.Add( "rocks.kfs.Intacct.PROJECTID" );
+
+            var rockContext = new RockContext();
+            var accountCategoryId = new CategoryService( rockContext ).Queryable().FirstOrDefault( c => c.Guid.Equals( new System.Guid( KFSConst.Attribute.FINANCIAL_ACCOUNT_ATTRIBUTE_CATEGORY ) ) ).Id;
+            var gatewayCategoryId = new CategoryService( rockContext ).Queryable().FirstOrDefault( c => c.Guid.Equals( new System.Guid( KFSConst.Attribute.FINANCIAL_GATEWAY_ATTRIBUTE_CATEGORY ) ) ).Id;
+            var attributeService = new AttributeService( rockContext );
+            var accountAttributes = attributeService.Queryable().Where( a => a.Categories.Select( c => c.Id ).Contains( accountCategoryId ) ).ToList();
+
+            var customDimensions = new List<string>();
+
+            foreach ( var attribute in accountAttributes )
+            {
+                if ( !knownDimensions.Contains( attribute.Key ) )
+                {
+                    customDimensions.Add( attribute.Key );
+                }
+            }
+
+            return customDimensions;
+        }
+
+        public static Dictionary<string, object> GetMergeFieldsAndDimensions( ref string debugLava, Dictionary<string, dynamic> customDimensionValues, MergeFieldObjects mergeFieldObjects )
+        {
+            var mergeFields = new Dictionary<string, object>();
+            var account = mergeFieldObjects.Account;
+            account.LoadAttributes();
+
+            if ( mergeFieldObjects.CustomDimensions.Count > 0 )
+            {
+                foreach ( var rockKey in mergeFieldObjects.CustomDimensions )
+                {
+                    var dimension = rockKey.Split( '.' ).Last();
+                    customDimensionValues.Add( dimension, account.GetAttributeValue( rockKey ) );
+                }
+            }
+
+            mergeFields.Add( "Account", account );
+            mergeFields.Add( "Summary", mergeFieldObjects.Summary );
+            mergeFields.Add( "Batch", mergeFieldObjects.Batch );
+            mergeFields.Add( "Registrations", mergeFieldObjects.Registrations );
+            mergeFields.Add( "GroupMembers", mergeFieldObjects.GroupMembers );
+            mergeFields.Add( "CustomDimensions", customDimensionValues );
+
+            if ( debugLava.Length < 6 && debugLava.AsBoolean() )
+            {
+                debugLava = mergeFields.lavaDebugInfo();
+            }
+
+            return mergeFields;
+        }
+    }
+
+    public class MergeFieldObjects
+    {
+        public FinancialAccount Account { get; set; }
+        public GLTransaction Summary { get; set; }
+        public FinancialBatch Batch { get; set; }
+        public List<RegistrationInstance> Registrations { get; set; }
+        public List<GroupMember> GroupMembers { get; set; }
+        public List<string> CustomDimensions { get; set; }
+    }
+}

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -175,7 +175,6 @@ namespace rocks.kfs.Intacct.Utils
         {
             var mergeFields = new Dictionary<string, object>();
             var account = mergeFieldObjects.Account;
-            account.LoadAttributes();
 
             if ( mergeFieldObjects.CustomDimensions.Count > 0 )
             {

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -72,7 +72,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\PaymentMethod.cs" />
     <Compile Include="IntacctCheckingAccountList.cs" />
+    <Compile Include="IntacctOtherReceipt.cs" />
     <Compile Include="IntacctJournal.cs" />
     <Compile Include="IntacctModels.cs" />
     <Compile Include="Migrations\002_AddTransactionFeeAttributes.cs" />

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -83,6 +83,7 @@
     <Compile Include="IntacctEndpoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SystemGuid\Attribute.cs" />
+    <Compile Include="Utils\TransactionHelpers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -63,6 +63,7 @@
       <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IntacctCheckingAccountList.cs" />
     <Compile Include="IntacctJournal.cs" />
     <Compile Include="IntacctModels.cs" />
     <Compile Include="Migrations\002_AddTransactionFeeAttributes.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Enhanced KFS's Intacct api interface to support creation of Other Receipts in Intacct account.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Enhanced KFS's Intacct api interface to support creation of Other Receipts in Intacct account.

---------

### Requested By

##### Who reported, requested, or paid for the change?

River Point Church

---------

### Screenshots

##### Does this update or add options to the block UI?

See RockBlocks PR for details.

---------

### Change Log

##### What files does it affect?

* rocks.kfs.Intacct/Enums/PaymentMethod.cs
* rocks.kfs.Intacct/IntacctCheckingAccountList.cs
* rocks.kfs.Intacct/IntacctEndpoint.cs
* rocks.kfs.Intacct/IntacctModels.cs
* rocks.kfs.Intacct/IntacctOtherReceipt.cs
* rocks.kfs.Intacct/rocks.kfs.Intacct.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
