### PR TITLE
Steps to Care - Notification Preferences and Workers Only

### DIFF
--- a/rocks.kfs.StepsToCare/Migrations/003_CreateCommunications.cs
+++ b/rocks.kfs.StepsToCare/Migrations/003_CreateCommunications.cs
@@ -45,11 +45,11 @@ namespace rocks.kfs.StepsToCare
     <b>Name:</b> {{ CareNeed.PersonAlias.Person.FullName }}<br>
     <b>Category:</b> {{ CareNeed.Category.Value }}<br>
     <b>Details:</b> {{ CareNeed.Details }}</blockquote>
-    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
+    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
 {{ 'Global' | Attribute:'EmailFooter' }}
 ", SystemGuid.SystemCommunication.CARE_NEED_FOLLOWUP, true, @"A Care Need has been flagged for follow up
 ""{{ CareNeed.Details | Truncate:20,'...' }}""
-{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
+{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}" );
 
             RockMigrationHelper.UpdateSystemCommunication( "Plugins", "Outstanding Care Needs", "", "", "", "", "", "Outstanding Care Needs", @"{{ 'Global' | Attribute:'EmailHeader' }}
 <table class='row' style='border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;'>
@@ -95,7 +95,7 @@ namespace rocks.kfs.StepsToCare
                                                 <table border='0' cellpadding='0' cellspacing='0' class='button-shell'>
                                                    <tbody>
                                                       <tr>
-                                                         <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Detail' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDetail }}?CareNeedId={{ careNeed.Id }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: normal;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 6px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;font-size: 14px'>View Detail</a></td>
+                                                         <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Detail' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDetail }}?CareNeedId={{ careNeed.Id }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: normal;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 6px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;font-size: 14px'>View Detail</a></td>
                                                       </tr>
                                                    </tbody>
                                                 </table>
@@ -128,7 +128,7 @@ namespace rocks.kfs.StepsToCare
             <table border='0' cellpadding='0' cellspacing='0' class='button-shell'>
                <tbody>
                   <tr>
-                     <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Care Dashboard' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: bold;font-size: 16px;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 15px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;'>View Care Dashboard</a></td>
+                     <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Care Dashboard' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: bold;font-size: 16px;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 15px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;'>View Care Dashboard</a></td>
                   </tr>
                </tbody>
             </table>
@@ -138,7 +138,7 @@ namespace rocks.kfs.StepsToCare
 </table>
 {{ 'Global' | Attribute:'EmailFooter' }}", SystemGuid.SystemCommunication.CARE_NEED_OUTSTANDING_NEEDS, true, @"{{ Person.NickName }},
 You currently have {{ CareNeeds | Size }} care needs assigned to you.
-View them at {{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
+View them at {{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}" );
 
             RockMigrationHelper.UpdateSystemCommunication( "Plugins", "Care Touch Needed", "", "", "", "", "", "Your assigned Care Need requires attention", @"{{ 'Global' | Attribute:'EmailHeader' }}
     <p>{{ Person.FullName }},</p>
@@ -148,11 +148,11 @@ View them at {{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/'
     <b>Name:</b> {{ CareNeed.PersonAlias.Person.FullName }}<br>
     <b>Details:</b> {{ CareNeed.Details }}<br>
     <b>Care Touches:</b> {{ TouchCount }}</blockquote>
-    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
+    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
 {{ 'Global' | Attribute:'EmailFooter' }}
 ", SystemGuid.SystemCommunication.CARE_NEED_TOUCH_NEEDED, true, @"Your assigned Care Need requires attention: 
 ""{{ CareNeed.Details | Truncate:20,'...' }}""
-{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
+{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}" );
 
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", SystemGuid.SystemCommunication.CARE_NEED_ASSIGNED ) );
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", SystemGuid.SystemCommunication.CARE_NEED_FOLLOWUP ) );

--- a/rocks.kfs.StepsToCare/Migrations/003_CreateCommunications.cs
+++ b/rocks.kfs.StepsToCare/Migrations/003_CreateCommunications.cs
@@ -31,9 +31,11 @@ namespace rocks.kfs.StepsToCare
     <b>Name:</b> {{ CareNeed.PersonAlias.Person.FullName }}<br>
     <b>Category:</b> {{ CareNeed.Category.Value }}<br>
     <b>Details:</b> {{ CareNeed.Details }}</blockquote>
-    <p><a href='{{ 'Global' | Attribute:'PublicApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
+    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
 {{ 'Global' | Attribute:'EmailFooter' }}
-", SystemGuid.SystemCommunication.CARE_NEED_ASSIGNED );
+", SystemGuid.SystemCommunication.CARE_NEED_ASSIGNED, true, @"You have been assigned a new Care Need for {{ CareNeed.PersonAlias.Person.FullName }}.
+""{{ CareNeed.Details | Truncate:20,'...' }}""
+{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}{{ LinkedPages.CareDashboard }}" );
 
             RockMigrationHelper.UpdateSystemCommunication( "Plugins", "Care Need Follow Up", "", "", "", "", "", "Care Need Follow Up Required", @"{{ 'Global' | Attribute:'EmailHeader' }}
     <p>{{ Person.FullName }},</p>
@@ -43,9 +45,11 @@ namespace rocks.kfs.StepsToCare
     <b>Name:</b> {{ CareNeed.PersonAlias.Person.FullName }}<br>
     <b>Category:</b> {{ CareNeed.Category.Value }}<br>
     <b>Details:</b> {{ CareNeed.Details }}</blockquote>
-    <p><a href='{{ 'Global' | Attribute:'PublicApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
+    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
 {{ 'Global' | Attribute:'EmailFooter' }}
-", SystemGuid.SystemCommunication.CARE_NEED_FOLLOWUP );
+", SystemGuid.SystemCommunication.CARE_NEED_FOLLOWUP, true, @"A Care Need has been flagged for follow up
+""{{ CareNeed.Details | Truncate:20,'...' }}""
+{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
 
             RockMigrationHelper.UpdateSystemCommunication( "Plugins", "Outstanding Care Needs", "", "", "", "", "", "Outstanding Care Needs", @"{{ 'Global' | Attribute:'EmailHeader' }}
 <table class='row' style='border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;'>
@@ -91,7 +95,7 @@ namespace rocks.kfs.StepsToCare
                                                 <table border='0' cellpadding='0' cellspacing='0' class='button-shell'>
                                                    <tbody>
                                                       <tr>
-                                                         <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Detail' href='{{ 'Global' | Attribute:'PublicApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDetail }}?CareNeedId={{ careNeed.Id }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: normal;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 6px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;font-size: 14px'>View Detail</a></td>
+                                                         <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Detail' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDetail }}?CareNeedId={{ careNeed.Id }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: normal;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 6px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;font-size: 14px'>View Detail</a></td>
                                                       </tr>
                                                    </tbody>
                                                 </table>
@@ -124,7 +128,7 @@ namespace rocks.kfs.StepsToCare
             <table border='0' cellpadding='0' cellspacing='0' class='button-shell'>
                <tbody>
                   <tr>
-                     <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Care Dashboard' href='{{ 'Global' | Attribute:'PublicApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: bold;font-size: 16px;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 15px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;'>View Care Dashboard</a></td>
+                     <td align='center' valign='middle' class='button-content' style='border-radius: 3px; background-color: rgb(0, 0, 0);'><a class='button-link' title='View Care Dashboard' href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}' target='_blank' style='color: rgb(255, 255, 255);display: inline-block;font-weight: bold;font-size: 16px;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;background-color: rgb(0, 0, 0);padding: 15px;border: 1px solid rgb(0, 0, 0);border-radius: 3px;'>View Care Dashboard</a></td>
                   </tr>
                </tbody>
             </table>
@@ -132,7 +136,9 @@ namespace rocks.kfs.StepsToCare
       </tr>
    </tbody>
 </table>
-{{ 'Global' | Attribute:'EmailFooter' }}", SystemGuid.SystemCommunication.CARE_NEED_OUTSTANDING_NEEDS );
+{{ 'Global' | Attribute:'EmailFooter' }}", SystemGuid.SystemCommunication.CARE_NEED_OUTSTANDING_NEEDS, true, @"{{ Person.NickName }},
+You currently have {{ CareNeeds | Size }} care needs assigned to you.
+View them at {{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
 
             RockMigrationHelper.UpdateSystemCommunication( "Plugins", "Care Touch Needed", "", "", "", "", "", "Your assigned Care Need requires attention", @"{{ 'Global' | Attribute:'EmailHeader' }}
     <p>{{ Person.FullName }},</p>
@@ -142,9 +148,11 @@ namespace rocks.kfs.StepsToCare
     <b>Name:</b> {{ CareNeed.PersonAlias.Person.FullName }}<br>
     <b>Details:</b> {{ CareNeed.Details }}<br>
     <b>Care Touches:</b> {{ TouchCount }}</blockquote>
-    <p><a href='{{ 'Global' | Attribute:'PublicApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
+    <p><a href='{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}'>View Care Dashboard</a></p>
 {{ 'Global' | Attribute:'EmailFooter' }}
-", SystemGuid.SystemCommunication.CARE_NEED_TOUCH_NEEDED );
+", SystemGuid.SystemCommunication.CARE_NEED_TOUCH_NEEDED, true, @"Your assigned Care Need requires attention: 
+""{{ CareNeed.Details | Truncate:20,'...' }}""
+{{ 'Global' | Attribute:'InternalApplicationRoot' | ReplaceLast:'/','' }}/{{ LinkedPages.CareDashboard }}" );
 
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", SystemGuid.SystemCommunication.CARE_NEED_ASSIGNED ) );
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", SystemGuid.SystemCommunication.CARE_NEED_FOLLOWUP ) );

--- a/rocks.kfs.StepsToCare/Migrations/006_AddWorkersOnlyColumn.cs
+++ b/rocks.kfs.StepsToCare/Migrations/006_AddWorkersOnlyColumn.cs
@@ -1,0 +1,42 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare
+{
+    [MigrationNumber( 6, "1.12.3" )]
+    public class AddWorkersOnlyColumn : Migration
+    {
+        public override void Up()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] ADD [WorkersOnly] BIT NOT NULL
+                    CONSTRAINT DF__rocks_kfs_StepsToCare_CareNeed_WorkersOnly
+                    DEFAULT (0)
+            " );
+        }
+
+        public override void Down()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] DROP CONSTRAINT [DF__rocks_kfs_StepsToCare_CareNeed_WorkersOnly]
+
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] DROP COLUMN [WorkersOnly]
+            " );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Migrations/007_CreateAttribute.cs
+++ b/rocks.kfs.StepsToCare/Migrations/007_CreateAttribute.cs
@@ -1,0 +1,40 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Collections.Generic;
+using Rock;
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare
+{
+    [MigrationNumber( 7, "1.12.3" )]
+    public class CreateAttribute : Migration
+    {
+        public override void Up()
+        {
+            RockMigrationHelper.AddOrUpdatePersonAttributeByGuid( Rock.SystemGuid.FieldType.SINGLE_SELECT, new List<string>(), "Steps to Care Notification", "Steps to Care Notification", "rocks_kfs_StepsToCare_Notification", "", "Choose how you would like to receive Steps to Care notifications. Default: Email", 0, "Email", SystemGuid.PersonAttribute.NOTIFICATION );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.PersonAttribute.NOTIFICATION, "values", "None^None,Email^Email,SMS^SMS,Both^Email & SMS", "A8E56BDB-8523-4BEA-9707-5C1463750BBB" );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.PersonAttribute.NOTIFICATION, "fieldtype", "rb", "C56B40EA-1594-448C-9742-50B3477EC04A" );
+
+            Sql( string.Format( "UPDATE [Attribute] SET IsSystem = 1 WHERE [Guid] = '{0}'", SystemGuid.PersonAttribute.NOTIFICATION ) );
+        }
+
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( SystemGuid.PersonAttribute.NOTIFICATION );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
+++ b/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
@@ -1,0 +1,94 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Collections.Generic;
+using Rock;
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare
+{
+    [MigrationNumber( 8, "1.12.3" )]
+    public class LavaShortcode : Migration
+    {
+        public override void Up()
+        {
+            Sql( @"IF NOT EXISTS (SELECT Id FROM [LavaShortcode] WHERE [Guid] = 'AB79EC07-F404-43DC-8F79-9A2AF87F04C6')
+BEGIN
+INSERT INTO [LavaShortcode] ([Name], [Description], [Documentation], [IsSystem], [IsActive], [TagName], [Markup], [TagType], [EnabledLavaCommands], [Parameters], [Guid])
+VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/quick note icon to any entity with a person ID. Using KFS Steps to Care ""Note Templates""', N'<p><b>Usage:</b> (Adds a person note to Person Id 123, with a prefix of ""Note: ""</p>
+<pre>{[ kfsnotepopover id:''123'' prefix:''Note'' ]}</pre>
+<p></p>
+<p><b>Parameters:</b></p><p>&nbsp; &nbsp; id: &lt;personId&gt; (required)</p>
+<p>&nbsp; &nbsp; prefix: &lt;string&gt; (optional)</p>
+<p>&nbsp; &nbsp; icon: &lt;font awesome icon string&gt; (default: ""fa fa-comment"")<br></p>
+<p><b>Example Appearance:</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href=""#""><i class=""fa fa-comment""></i></a></p>
+', '0', '1', N'kfsnotepopover', N'<a tabindex=""0"" role=""button"" data-toggle=""popoverCustom"" data-id=""{{ id }}"" class=""kfs-popover""><i class=""{{ icon }}""></i></a>
+{% javascript id:''kfsNotePopover'' disableanonymousfunction:''true'' %}
+    $(function () {
+        $(''[data-toggle=""popoverCustom""]'').each (function () {
+          $(this).popover({
+              //trigger: ''focus'',
+              placement: ''top'',
+              html:''true'',
+              sanitize: false,
+              content:''{% notetemplate where:''IsActive == true && Id != 6'' %}{% for template in notetemplateItems %}<a href=""#"" onclick=""addNoteAjax(\''{{ prefix }}\'',this.title,'' + $(this).data(''id'')+'');return false;"" title=""{{ template.Note }}"" class=""mx-2""><i class=""{{ template.Icon }}""></i></a>{%- endfor %}{% endnotetemplate %}''
+          });
+        });
+    });
+    
+    function addNoteAjax(prefix = """", message, id) { 
+        var prefixPlus = """";
+        if (prefix != """") {
+            prefixPlus = "": "";
+        }
+        $.ajax({
+            type: ""POST"",
+            url: ""/api/Notes"", 
+            contentType:""application/json"",
+            data: JSON.stringify({
+                IsSystem: false,
+                Text: prefix.trim()+prefixPlus+message,
+                NoteTypeId: 4,
+                EntityId: id,
+                CreatedByPersonAliasId: {{ CurrentPerson.PrimaryAliasId }},
+                ApprovalStatus: 1,
+                IsAlert: false,
+                Caption: """"
+            }),
+            success: function( data ) {
+                alert( prefix+"" Added: ""+message);
+            },
+            error: function (e) {
+                console.error(e);
+            }
+        });
+    }
+{% endjavascript %}
+{% stylesheet id:''kfsNotePopoverStyles'' %}
+.kfs-popover + .popover .popover-content {
+    white-space: nowrap;
+}
+{% endstylesheet %}
+', '1', N'RockEntity', N'id^|prefix^|icon^fa fa-comment', 'AB79EC07-F404-43DC-8F79-9A2AF87F04C6')
+END" );
+        }
+
+        public override void Down()
+        {
+            Sql( @"DELETE LavaShortcode WHERE [Guid] = 'AB79EC07-F404-43DC-8F79-9A2AF87F04C6'" );
+        }
+    }
+}                                                                                                                                                                         

--- a/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
+++ b/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
@@ -40,7 +40,7 @@ VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/qui
     $(function () {
         $(''[data-toggle=""popoverCustom""]'').each (function () {
           $(this).popover({
-              //trigger: ''focus'',
+              trigger: ''focus'',
               placement: ''top'',
               html:''true'',
               sanitize: false,

--- a/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
+++ b/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
@@ -44,7 +44,7 @@ VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/qui
               placement: ''top'',
               html:''true'',
               sanitize: false,
-              content:''{% notetemplate where:''IsActive == true && Id != 6'' %}{% for template in notetemplateItems %}<a href=""#"" onclick=""addNoteAjax(\''{{ prefix }}\'',this.title,'' + $(this).data(''id'')+'');return false;"" title=""{{ template.Note }}"" class=""mx-2""><i class=""{{ template.Icon }}""></i></a>{%- endfor %}{% endnotetemplate %}''
+              content:''{% notetemplate where:''IsActive == true'' %}{% for template in notetemplateItems %}<a href=""#"" onclick=""addNoteAjax(\''{{ prefix }}\'',this.title,'' + $(this).data(''id'')+'');return false;"" title=""{{ template.Note }}"" class=""mx-2""><i class=""{{ template.Icon }}""></i></a>{%- endfor %}{% endnotetemplate %}''
           });
         });
     });

--- a/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
+++ b/rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
@@ -35,7 +35,7 @@ VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/qui
 <p>&nbsp; &nbsp; prefix: &lt;string&gt; (optional)</p>
 <p>&nbsp; &nbsp; icon: &lt;font awesome icon string&gt; (default: ""fa fa-comment"")<br></p>
 <p><b>Example Appearance:</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href=""#""><i class=""fa fa-comment""></i></a></p>
-', '0', '1', N'kfsnotepopover', N'<a tabindex=""0"" role=""button"" data-toggle=""popoverCustom"" data-id=""{{ id }}"" class=""kfs-popover""><i class=""{{ icon }}""></i></a>
+', '0', '1', N'kfsnotepopover', N'<a tabindex=""0"" role=""button"" data-toggle=""popoverCustom"" data-id=""{{ id }}"" data-prefix=""{{ prefix }}"" class=""kfs-popover""><i class=""{{ icon }}""></i></a>
 {% javascript id:''kfsNotePopover'' disableanonymousfunction:''true'' %}
     $(function () {
         $(''[data-toggle=""popoverCustom""]'').each (function () {
@@ -44,12 +44,13 @@ VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/qui
               placement: ''top'',
               html:''true'',
               sanitize: false,
-              content:''{% notetemplate where:''IsActive == true'' %}{% for template in notetemplateItems %}<a href=""#"" onclick=""addNoteAjax(\''{{ prefix }}\'',this.title,'' + $(this).data(''id'')+'');return false;"" title=""{{ template.Note }}"" class=""mx-2""><i class=""{{ template.Icon }}""></i></a>{%- endfor %}{% endnotetemplate %}''
+              content:''{% notetemplate where:''IsActive == true'' %}{% for template in notetemplateItems %}<a href=""#"" onclick=""addNoteAjax(\'''' + $(this).data(''prefix'') +''\'',this.title,'' + $(this).data(''id'')+'');return false;"" title=""{{ template.Note }}"" class=""mx-2""><i class=""{{ template.Icon }}""></i></a>{%- endfor %}{% endnotetemplate %}''
           });
         });
     });
     
-    function addNoteAjax(prefix = """", message, id) { 
+    function addNoteAjax(prefix = """", message, id) {
+        $(''#updateProgress'').show();
         var prefixPlus = """";
         if (prefix != """") {
             prefixPlus = "": "";
@@ -69,10 +70,12 @@ VALUES (N'KFS Note Popover', N'Use this shortcode to add person note popover/qui
                 Caption: """"
             }),
             success: function( data ) {
+                $(''#updateProgress'').hide();
                 alert( prefix+"" Added: ""+message);
             },
             error: function (e) {
                 console.error(e);
+                $(''#updateProgress'').hide();
             }
         });
     }

--- a/rocks.kfs.StepsToCare/Migrations/009_CreatePermissions.cs
+++ b/rocks.kfs.StepsToCare/Migrations/009_CreatePermissions.cs
@@ -1,0 +1,38 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Collections.Generic;
+using Rock;
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare
+{
+    [MigrationNumber( 9, "1.12.3" )]
+    public class CreatePermissions : Migration
+    {
+        public override void Up()
+        {
+            RockMigrationHelper.AddSecurityAuthForBlock( "EADBE3F0-F64B-4583-B49D-F0031BBC929F", 0, "ViewAll", true, Rock.SystemGuid.Group.GROUP_ADMINISTRATORS, Rock.Model.SpecialRole.None, "B841217C-327B-4753-BA76-C5ED1F2748EE" );
+            RockMigrationHelper.AddSecurityAuthForBlock( "EADBE3F0-F64B-4583-B49D-F0031BBC929F", 0, "CareWorkers", true, Rock.SystemGuid.Group.GROUP_ADMINISTRATORS, Rock.Model.SpecialRole.None, "037202FE-5A6B-4D3B-9C1D-6F5AD65A5D06" );
+        }
+
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteSecurityAuth( "037202FE-5A6B-4D3B-9C1D-6F5AD65A5D06" );
+            RockMigrationHelper.DeleteSecurityAuth( "B841217C-327B-4753-BA76-C5ED1F2748EE" );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Model/CareNeed.cs
+++ b/rocks.kfs.StepsToCare/Model/CareNeed.cs
@@ -76,6 +76,9 @@ namespace rocks.kfs.StepsToCare.Model
         [FieldType( Rock.SystemGuid.FieldType.CAMPUS )]
         public int? CampusId { get; set; }
 
+        [DataMember]
+        public bool WorkersOnly { get; set; }
+
         #endregion Entity Properties
 
         #region Virtual Properties

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/SystemGuid/PersonAttribute.cs
+++ b/rocks.kfs.StepsToCare/SystemGuid/PersonAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace rocks.kfs.StepsToCare.SystemGuid
+{
+    /// <summary>
+    /// Custom KFS Person Attributes for Steps to Care plugin
+    /// </summary>
+    public class PersonAttribute
+    {
+        /// <summary>
+        /// The Care Need category defined type.
+        /// </summary>
+        public const string NOTIFICATION = "330C665A-E348-40D8-8D56-01D7E2466CC5";
+    }
+}

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -46,8 +46,9 @@
     <Reference Include="Quartz">
       <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
     </Reference>
-    <Reference Include="Rock">
-      <HintPath>..\RockWeb\Bin\Rock.dll</HintPath>
+    <Reference Include="Rock, Version=1.12.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -65,6 +66,7 @@
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
     <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />
+    <Compile Include="Migrations\007_CreateAttribute.cs" />
     <Compile Include="Migrations\005_CreateJob.cs" />
     <Compile Include="Migrations\004_CreatePages.cs" />
     <Compile Include="Migrations\003_CreateCommunications.cs" />
@@ -79,6 +81,7 @@
     <Compile Include="Model\NoteTemplate.cs" />
     <Compile Include="Model\NoteTemplateService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemGuid\PersonAttribute.cs" />
     <Compile Include="SystemGuid\SystemCommunication.cs" />
     <Compile Include="SystemGuid\DefinedValue.cs" />
     <Compile Include="SystemGuid\DefinedType.cs" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
+    <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />
     <Compile Include="Migrations\005_CreateJob.cs" />
     <Compile Include="Migrations\004_CreatePages.cs" />
     <Compile Include="Migrations\003_CreateCommunications.cs" />
@@ -84,7 +85,6 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
     <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />
+    <Compile Include="Migrations\008_LavaShortcode.cs" />
     <Compile Include="Migrations\007_CreateAttribute.cs" />
     <Compile Include="Migrations\005_CreateJob.cs" />
     <Compile Include="Migrations\004_CreatePages.cs" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotLiquid">
-      <HintPath>..\RockWeb\Bin\DotLiquid.dll</HintPath>
+    <Reference Include="DotLiquid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\DotLiquid.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
@@ -66,6 +67,7 @@
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
     <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />
+    <Compile Include="Migrations\009_CreatePermissions.cs" />
     <Compile Include="Migrations\008_LavaShortcode.cs" />
     <Compile Include="Migrations\007_CreateAttribute.cs" />
     <Compile Include="Migrations\005_CreateJob.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Add the new Workers Only column to the data model and table. 
- Add a new person attribute for notification preferences. 
- Update the communication migration to include the proper URL's and SMS values. 
- Update the Job for the new notification preferences and sending SMS.
- Added a Lava shortcode via migration for note template/quick notes capability.
- Added migration for new security permissions added in https://github.com/KingdomFirst/RockBlocks/pull/85

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Add the new Workers Only column to the data model and table. 
- Add a new person attribute for notification preferences. 
- Update the communication migration to include the proper URL's and SMS values. 
- Update the Job for the new notification preferences and sending SMS.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Rock Springs

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
- rocks.kfs.StepsToCare/Migrations/003_CreateCommunications.cs
- rocks.kfs.StepsToCare/Migrations/006_AddWorkersOnlyColumn.cs
- rocks.kfs.StepsToCare/Migrations/007_CreateAttribute.cs
- rocks.kfs.StepsToCare/Migrations/008_LavaShortcode.cs
- rocks.kfs.StepsToCare/Migrations/009_CreatePermissions.cs
- rocks.kfs.StepsToCare/Model/CareNeed.cs
- rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
- rocks.kfs.StepsToCare/SystemGuid/PersonAttribute.cs
- rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Requires Rock 12.4+ due to GetAttributeValue by Guid
