### PR TITLE
Scheduled Group Communication: Daily Recurrence Option

### DIFF
--- a/KFSRock.sln.kfs
+++ b/KFSRock.sln.kfs
@@ -6,7 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "RockWeb", "RockWeb\", "{E43B5D55-BED0-4E74-BF97-9327F9A9D656}"
 	ProjectSection(WebsiteProperties) = preProject
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.5.2"
-		ProjectReferences = "{00edcb8d-ef33-459c-ad62-02876bd24dff}|DotLiquid.dll;{185a31d7-3037-4dae-8797-0459849a84bd}|Rock.dll;{d6b19c0d-da5e-4f75-8001-04ded86b741f}|Rock.Mailgun.dll;{cf8c694a-55a0-434f-bc96-3450b96ec12a}|Rock.Mandrill.dll;{704740d8-b539-4560-9f8c-681670c9d6ad}|Rock.Migrations.dll;{f3692909-952d-4c4a-b2d2-d90d0083cf53}|Rock.NMI.dll;{a005d091-140e-4ec4-bcdf-cf7d42bb702c}|Rock.PayFlowPro.dll;{add1edd0-a4cb-4e82-b6ad-6ad1d556deae}|Rock.Rest.dll;{6fe0930c-6832-4c2f-8a76-d4e4a2d80ddf}|Rock.Version.dll;{1f5956f2-2b0f-49b8-aaf1-2cc28f01426a}|Rock.SignNow.dll;{69AC175C-3997-4514-8C9E-5D24811928C2}|SignNowSDK.dll;{c1dd2402-5fb2-411e-bf8d-5d9cb3a58e8b}|Rock.Slingshot.dll;{962944DE-8BF4-4175-B55A-E75CF7918272}|Rock.Slingshot.Model.dll;{42edf2dd-5284-4b64-93c3-5186619d2b14}|Rock.StatementGenerator.dll;{5055f482-72c7-4cc9-8ed0-a77090c777db}|Rock.Security.Authentication.Auth0.dll;{515e22e4-4b9b-4886-8477-e5b312b75eb4}|Rock.WebStartup.dll;{94a5f880-31ae-4889-b9be-ba1fdc258e83}|Rock.Checkr.dll;{cadd9206-2c6b-42e4-b20b-2dfc3eb4d6d4}|Rock.DownhillCss.dll;{13711bed-69dd-4182-9bb5-b3c9a4de32df}|Rock.MyWell.dll;{205f439a-2ccc-42c1-b1ab-09e1b629d88c}|Rock.SendGrid.dll;{8ccb8e2a-073c-48cb-b31a-621ec5430a42}|Rock.Oidc.dll;{bc36cac2-1f25-4190-9297-157ddd2e4960}|cc.newspring.AttendedCheckIn.dll;"
+		ProjectReferences = "{00edcb8d-ef33-459c-ad62-02876bd24dff}|DotLiquid.dll;{185a31d7-3037-4dae-8797-0459849a84bd}|Rock.dll;{d6b19c0d-da5e-4f75-8001-04ded86b741f}|Rock.Mailgun.dll;{cf8c694a-55a0-434f-bc96-3450b96ec12a}|Rock.Mandrill.dll;{704740d8-b539-4560-9f8c-681670c9d6ad}|Rock.Migrations.dll;{f3692909-952d-4c4a-b2d2-d90d0083cf53}|Rock.NMI.dll;{a005d091-140e-4ec4-bcdf-cf7d42bb702c}|Rock.PayFlowPro.dll;{add1edd0-a4cb-4e82-b6ad-6ad1d556deae}|Rock.Rest.dll;{6fe0930c-6832-4c2f-8a76-d4e4a2d80ddf}|Rock.Version.dll;{1f5956f2-2b0f-49b8-aaf1-2cc28f01426a}|Rock.SignNow.dll;{69AC175C-3997-4514-8C9E-5D24811928C2}|SignNowSDK.dll;{c1dd2402-5fb2-411e-bf8d-5d9cb3a58e8b}|Rock.Slingshot.dll;{962944DE-8BF4-4175-B55A-E75CF7918272}|Rock.Slingshot.Model.dll;{42edf2dd-5284-4b64-93c3-5186619d2b14}|Rock.StatementGenerator.dll;{5055f482-72c7-4cc9-8ed0-a77090c777db}|Rock.Security.Authentication.Auth0.dll;{515e22e4-4b9b-4886-8477-e5b312b75eb4}|Rock.WebStartup.dll;{94a5f880-31ae-4889-b9be-ba1fdc258e83}|Rock.Checkr.dll;{cadd9206-2c6b-42e4-b20b-2dfc3eb4d6d4}|Rock.DownhillCss.dll;{13711bed-69dd-4182-9bb5-b3c9a4de32df}|Rock.MyWell.dll;{205f439a-2ccc-42c1-b1ab-09e1b629d88c}|Rock.SendGrid.dll;{8ccb8e2a-073c-48cb-b31a-621ec5430a42}|Rock.Oidc.dll;{b62b27c8-1f77-43cf-8ee7-30de7f93facd}|Rock.Update.dll;{bc36cac2-1f25-4190-9297-157ddd2e4960}|cc.newspring.AttendedCheckIn.dll;{e3c37e39-0dae-4826-b38f-eb6a4d23842f}|com.centralaz.RoomManagement.dll;"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_6229"
 		Debug.AspNetCompiler.PhysicalPath = "RockWeb\"
 		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_6229\"
@@ -53,8 +53,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Slingshot", "Rock.Slin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Slingshot.Model", "Rock.Slingshot.Model\Rock.Slingshot.Model.csproj", "{962944DE-8BF4-4175-B55A-E75CF7918272}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Specs", "Rock.Specs\Rock.Specs.csproj", "{5BC16478-A45D-4F65-87B2-FFD61650D541}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.StatementGenerator", "Rock.StatementGenerator\Rock.StatementGenerator.csproj", "{42EDF2DD-5284-4B64-93C3-5186619D2B14}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Security.Authentication.Auth0", "Rock.Security.Authentication.Auth0\Rock.Security.Authentication.Auth0.csproj", "{5055F482-72C7-4CC9-8ED0-A77090C777DB}"
@@ -80,6 +78,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.SendGrid", "Rock.SendGrid\Rock.SendGrid.csproj", "{205F439A-2CCC-42C1-B1AB-09E1B629D88C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Oidc", "Rock.Oidc\Rock.Oidc.csproj", "{8CCB8E2A-073C-48CB-B31A-621EC5430A42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rock.Update", "Rock.Update\Rock.Update.csproj", "{B62B27C8-1F77-43CF-8EE7-30DE7F93FACD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cc.newspring.AttendedCheckIn", "RockAttendedCheckin\cc.newspring.AttendedCheckIn.csproj", "{BC36CAC2-1F25-4190-9297-157DDD2E4960}"
 EndProject
@@ -154,6 +154,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "com.centralaz.RoomManagement", "CentralAZ\com.CentralAZ.RoomManagement\com.centralaz.RoomManagement.csproj", "{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Workflow.Action.Core", "KFSRockAssemblies\rocks.kfs.Workflow.Action.Core\rocks.kfs.Workflow.Action.Core.csproj", "{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.StepsToCare", "KFSRockAssemblies\rocks.kfs.StepsToCare\rocks.kfs.StepsToCare.csproj", "{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -265,6 +267,10 @@ Global
 		{8CCB8E2A-073C-48CB-B31A-621EC5430A42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8CCB8E2A-073C-48CB-B31A-621EC5430A42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CCB8E2A-073C-48CB-B31A-621EC5430A42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B62B27C8-1F77-43CF-8EE7-30DE7F93FACD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B62B27C8-1F77-43CF-8EE7-30DE7F93FACD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B62B27C8-1F77-43CF-8EE7-30DE7F93FACD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B62B27C8-1F77-43CF-8EE7-30DE7F93FACD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BC36CAC2-1F25-4190-9297-157DDD2E4960}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC36CAC2-1F25-4190-9297-157DDD2E4960}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC36CAC2-1F25-4190-9297-157DDD2E4960}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -413,6 +419,10 @@ Global
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
@@ -237,6 +237,9 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                     case "3":
                                         sendDate.Value = sendDate.ValueAsDateTime.Value.AddMonths( 1 ).ToString();
                                         break;
+                                    case "4":
+                                        sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 1 ).ToString();
+                                        break;
                                     default:
                                         break;
                                 }

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -236,6 +236,9 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                         case "3":
                                             sendDate.Value = sendDate.ValueAsDateTime.Value.AddMonths( 1 ).ToString();
                                             break;
+                                        case "4":
+                                            sendDate.Value = sendDate.ValueAsDateTime.Value.AddDays( 1 ).ToString();
+                                            break;
                                         default:
                                             break;
                                     }

--- a/rocks.kfs.ScheduledGroupCommunication/Migrations/003_AddDailyRecurrence.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Migrations/003_AddDailyRecurrence.cs
@@ -1,0 +1,63 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.ScheduledGroupCommunication.SystemGuid;
+
+namespace rocks.kfs.ScheduledGroupCommunication.Migrations
+{
+    [MigrationNumber( 3, "1.7.4" )]
+    internal class AddDailyRecurrence : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            #region Email Attribute
+
+            // recurrence attribute
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "values", "0^OneTime,4^Daily,1^Weekly,2^BiWeekly,3^Monthly", "F1F0873E-CA36-4935-90F5-DFEFD79083C8" );
+
+            #endregion
+
+            #region SMS Attributes
+
+            var rockContextSMS = new RockContext();
+            var attributeMatrixTemplateSMSId = new AttributeMatrixTemplateService( rockContextSMS ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS.AsGuid() ).Id.ToString();
+
+            // recurrence attribute
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "values", "0^OneTime,4^Daily,1^Weekly,2^BiWeekly,3^Monthly", "4FAE15C5-C1AB-4FDB-B21D-CBF467B1D395" );
+
+            #endregion
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_EMAIL_SEND_RECURRENCE, "values", "0^OneTime,1^Weekly,2^BiWeekly,3^Monthly", "F1F0873E-CA36-4935-90F5-DFEFD79083C8" );
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE, "values", "0^OneTime,1^Weekly,2^BiWeekly,3^Monthly", "4FAE15C5-C1AB-4FDB-B21D-CBF467B1D395" );
+
+        }
+    }
+}

--- a/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.ScheduledGroupCommunication" )]
 [assembly: AssemblyProduct( "rocks.kfs.ScheduledGroupCommunication" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.6.*" )]
+[assembly: AssemblyVersion( "1.7.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.ScheduledGroupCommunication/ReadMe.md
+++ b/rocks.kfs.ScheduledGroupCommunication/ReadMe.md
@@ -3,9 +3,9 @@
 
 
 # Send Scheduled Group Communications
-*Tested/Supported in Rock version:  8.0-12.0*   
+*Tested/Supported in Rock version:  8.0-12.7*   
 *Created:  11/20/2018*  
-*Updated:  6/22/2021*   
+*Updated:  1/20/2022*   
 *Rock Shop Plugin: https://www.rockrms.com/Plugin/100*
 
 # Send Scheduled Group Communications
@@ -71,7 +71,7 @@ You will need to create two system jobs to send the communications.
 >
 > <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;2&nbsp;&nbsp;</span>**Cron Expression** Enter a cron expression for how often you want the job to run. Communications will be sent the next time the job runs after their scheduled send time.
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;3&nbsp;&nbsp;</span>**Job Type** For an email job, choose "rocks.kfs.GroupScheduledEmail.Jobs.SendScheduledGroupEmail" For an SMS job, choose "rocks.kfs.GroupScheduledSMS.Jobs.SendScheduledGroupSMS"
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;3&nbsp;&nbsp;</span>**Job Type** For an email job, choose "Send Scheduled Group Email (Plugin)" For an SMS job, choose "Send Scheduled Group SMS (Plugin)"
 >
 > <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;4&nbsp;&nbsp;</span>**Enabled Lava Commands** Choose which lava commands should be enabled for this job. If you would like to use any of these commands in your communication, they need to be enabled on the job.
 >

--- a/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
+++ b/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Jobs\SendScheduledGroupEmail.cs" />
     <Compile Include="Jobs\SendScheduledGroupSMS.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />
+    <Compile Include="Migrations\003_AddDailyRecurrence.cs" />
     <Compile Include="Migrations\002_AddRecurrenceAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SystemGuid\Attribute.cs" />


### PR DESCRIPTION
### Description 

Add option for daily scheduled group communications in both the email and text variety.

**New Settings:**

* Added Daily option to scheduled group emails
* Added Daily option to scheduled group texts

---------

### Release Notes 

* Added option for daily recurrence to scheduled group communications

---------

### Requested By

Venture

---------

### Screenshots

#### Email
![image](https://user-images.githubusercontent.com/2577926/150014618-aecb1811-d5bf-4ccb-9150-a9f932678f00.png)

#### Text
![image](https://user-images.githubusercontent.com/2577926/150014694-7cdd0806-9282-4b0d-9a73-adce5ade7460.png)


---------

### Change Log

* rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs - Added processing for daily emails
* rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs - Added processing for daily texts
* rocks.kfs.ScheduledGroupCommunication/Migrations/003_AddDailyRecurrence.cs - Migration to create Daily option
* rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj - Added migration to project file

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, only new options added

