### PR TITLE
EWS Shortcode Modifications

### DIFF
--- a/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
+++ b/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
@@ -72,7 +72,7 @@ namespace rocks.kfs.Shortcodes.EWS
             <li><strong>Body</strong> - The full body.</li>
             <li><strong>TextBody</strong> - The plain text representation of the body.</li>
             <li><strong>Location</strong> - The name of the location</li>
-            <li><strong>Start</strong> - The start dateTime. (Time Zone is based on authentication credentials user settings.)</li>
+            <li><strong>Start</strong> - The start dateTime. (Time Zone is based on the authenticated Exchange user settings.)</li>
             <li><strong>End</strong> - The end dateTime.</li>
             <li><strong>DisplayTo</strong> - A text summarization of the To recipients.</li>
             <li><strong>DisplayCc</strong> - A text summarization of the CC recipients.</li>

--- a/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
+++ b/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
@@ -38,10 +38,10 @@ namespace rocks.kfs.Shortcodes.EWS
     /// Lava shortcode for displaying calendar items from a Microsoft Exchange mailbox.
     /// </summary>
     [LavaShortcodeMetadata(
-        "EWS Calendar Items",
+        "KFS - EWS Calendar Items",
         "ewscalendaritems",
         "Retrieves a list of calendar items from a specified Microsoft Exchange shared calendar mailbox.",
-        @"<p>The EWS calendar items shortcode allows you to access calendar items from a specified Microsoft Exchange shared mailbox using the EWS managed API. Below is an example of how to use it.
+        @"<p>The KFS - EWS calendar items shortcode allows you to access calendar items from a specified Microsoft Exchange shared mailbox using the EWS managed API. Below is an example of how to use it.
             </p>
             <pre>{% assign username = 'Global' | Attribute:'rocks.kfs.EWSUsername' %}
 {% assign password = 'Global' | Attribute:'rocks.kfs.EWSPassword' %}

--- a/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
+++ b/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 
 using DotLiquid;
 using DotLiquid.Util;
@@ -71,7 +72,7 @@ namespace rocks.kfs.Shortcodes.EWS
             <li><strong>Body</strong> - The full body.</li>
             <li><strong>TextBody</strong> - The plain text representation of the body.</li>
             <li><strong>Location</strong> - The name of the location</li>
-            <li><strong>Start</strong> - The start dateTime.</li>
+            <li><strong>Start</strong> - The start dateTime. (Time Zone is based on authentication credentials user settings.)</li>
             <li><strong>End</strong> - The end dateTime.</li>
             <li><strong>DisplayTo</strong> - A text summarization of the To recipients.</li>
             <li><strong>DisplayCc</strong> - A text summarization of the CC recipients.</li>
@@ -286,6 +287,8 @@ namespace rocks.kfs.Shortcodes.EWS
                 }
                 catch ( Exception ex )
                 {
+                    ExceptionLogService.LogException( ex, HttpContext.Current );
+                    result.Write( string.Format( "<div class='alert alert-warning'>{0}</div>", ex.Message ) );
                     return;
                 }
                 if ( calendarItems.Count() == 0 )

--- a/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
+++ b/rocks.kfs.Shortcodes/EWS/CalendarItems.cs
@@ -45,7 +45,7 @@ namespace rocks.kfs.Shortcodes.EWS
         @"<p>The KFS - EWS calendar items shortcode allows you to access calendar items from a specified Microsoft Exchange shared mailbox using the EWS managed API. Below is an example of how to use it.
             </p>
             <pre>{% assign username = 'Global' | Attribute:'rocks.kfs.EWSUsername' %}
-{% assign password = 'Global' | Attribute:'rocks.kfs.EWSPassword' %}
+{% assign password = 'Global' | Attribute:'rocks.kfs.EWSPassword','RawValue' %}
 {[ ewscalendaritems username:'{{ username }}' password:'{{ password }}' calendarmailbox:'kfscalendar@kingdomfirstsolutions.com' ]}
     {% for calItem in CalendarItems %}
         {{ calItem.Subject }}

--- a/rocks.kfs.Shortcodes/Migrations/001_CreateAttribute.cs
+++ b/rocks.kfs.Shortcodes/Migrations/001_CreateAttribute.cs
@@ -27,6 +27,7 @@ namespace rocks.kfs.Shortcodes.Migrations
         {
             RockMigrationHelper.AddGlobalAttribute( Rock.SystemGuid.FieldType.ENCRYPTED_TEXT, null, null, "EWS Username", "The Microsoft Exchange server username to use with EWS managed API.", 0, null, "EDEEE121-BE8F-4B80-A567-80E8BB344346", "rocks.kfs.EWSUsername", true );
             RockMigrationHelper.AddGlobalAttribute( Rock.SystemGuid.FieldType.ENCRYPTED_TEXT, null, null, "EWS Password", "The Microsoft Exchange server password to use with EWS managed API.", 0, null, "0C278C32-C179-4EBE-AF40-F9AD509B8450", "rocks.kfs.EWSPassword", true );
+            RockMigrationHelper.AddAttributeQualifier( "0C278C32-C179-4EBE-AF40-F9AD509B8450","ispassword","true", "08839315-119B-4F39-8EF9-A05B65449392" );
         }
 
         public override void Down()

--- a/rocks.kfs.Shortcodes/rocks.kfs.Shortcodes.csproj
+++ b/rocks.kfs.Shortcodes/rocks.kfs.Shortcodes.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Once I went to use the EWS Shortcode there were a few minor changes needed.
- Gave the shortcode a new "Name" to prepend KFS to it. 
- Added a note to the "Start" time field that the time is based off of the authenticated user's time zone.
- Added exception log capability as I tried running it and couldn't figure out why it failed until I saw the error.
- Added Attribute Qualifier to the password field so the value doesn't display in global attributes .

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Gave the shortcode a new "Name" to prepend KFS to it. 
- Added a note to the "Start" time field that the time is based off of the authenticated user's time zone.
- Added exception log capability as I tried running it and couldn't figure out why it failed until I saw the error.
- Added Attribute Qualifier to the password field so the value doesn't display in global attributes .

---------

### Requested By

##### Who reported, requested, or paid for the change?

New Hope

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/154760132-2c1c7b5e-efee-43d7-b364-47e6477584b9.png)   

Error message display:   
![image](https://user-images.githubusercontent.com/2990519/154760099-ceee9797-7e70-427c-85dc-9a77e4fd34bd.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Shortcodes/EWS/CalendarItems.cs
- rocks.kfs.Shortcodes/Migrations/001_CreateAttribute.cs
- rocks.kfs.Shortcodes/rocks.kfs.Shortcodes.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
