### PR TITLE
Steps to Care Sub/Family Needs

### DIFF
--- a/rocks.kfs.StepsToCare/Migrations/001_CreateDb.cs
+++ b/rocks.kfs.StepsToCare/Migrations/001_CreateDb.cs
@@ -243,7 +243,7 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.DeleteEntityType( "87AC878D-6740-43EB-9389-B8440AC595C3" );
 
             Sql( @"
-                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_AssignedPerson] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_AssignedPerson_WorkerPersonAlias]
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_AssignedPerson] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_AssignedPerson_Worker]
                 ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_AssignedPerson] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_AssignedPerson_PersonAlias]
                 ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_AssignedPerson] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_AssignedPerson_ModifiedPersonAlias]
                 ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_AssignedPerson] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_AssignedPerson_CreatedPersonAlias]

--- a/rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs
+++ b/rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs
@@ -63,17 +63,17 @@ namespace rocks.kfs.StepsToCare.Migrations
             // Add Block Care Notes to Page: Care Entry, Site: Rock RMS
             RockMigrationHelper.AddBlock( true, "27953B65-21E2-4CA9-8461-3AFAD46D9BC8".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "2E9F32D4-B4FC-4A5F-9BE1-B2E3EA624DD3".AsGuid(), "Care Notes", "SectionA", @"", @"", 0, "A9F1F1C1-031B-4D87-BF52-0E5BC5423AC6" );
 
-            // Add Block Defined Value List - Categories to Page: Care Configuration, Site: Rock RMS
-            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "0AB2D5E9-9272-47D5-90E4-4AA838D2D3EE".AsGuid(), "Defined Value List - Categories", "SectionA", @"<div class=""col-sm-6"">", @"</div>", 0, "F588AEE4-3BFE-4025-AFF0-5C1569434924" );
-
-            // Add Block Defined Value List - Status to Page: Care Configuration, Site: Rock RMS
-            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "0AB2D5E9-9272-47D5-90E4-4AA838D2D3EE".AsGuid(), "Defined Value List - Status", "SectionA", @"<div class=""col-sm-6"">", @"</div>", 1, "362581DC-6224-40FA-B351-FC2572022166" );
-
             // Add Block Care Workers to Page: Care Configuration, Site: Rock RMS
-            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "FC3E03F3-80A0-42BF-AAFB-DD2095B7BE86".AsGuid(), "Care Workers", "Main", @"<div class=""col-md-6"">", @"</div>", 0, "8B0BBF03-2BAE-4B7D-9A4B-1CAE23F8E02E" );
+            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "FC3E03F3-80A0-42BF-AAFB-DD2095B7BE86".AsGuid(), "Care Workers", "Main", @"", @"", 0, "8B0BBF03-2BAE-4B7D-9A4B-1CAE23F8E02E" );
 
             // Add Block Care Note Templates to Page: Care Configuration, Site: Rock RMS
-            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "561E0D77-12F9-4863-B5E3-4C5F36FB2DB1".AsGuid(), "Care Note Templates", "Main", @"", @"", 1, "E4108097-F10B-4404-BD3C-D36D8DEB1A8B" );
+            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "561E0D77-12F9-4863-B5E3-4C5F36FB2DB1".AsGuid(), "Care Note Templates", "SectionB", @"", @"", 1, "E4108097-F10B-4404-BD3C-D36D8DEB1A8B" );
+
+            // Add Block Defined Value List - Categories to Page: Care Configuration, Site: Rock RMS
+            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "0AB2D5E9-9272-47D5-90E4-4AA838D2D3EE".AsGuid(), "Defined Value List - Categories", "SectionC", @"", @"", 0, "F588AEE4-3BFE-4025-AFF0-5C1569434924" );
+
+            // Add Block Defined Value List - Status to Page: Care Configuration, Site: Rock RMS
+            RockMigrationHelper.AddBlock( true, "39F72E9D-22B7-4F1E-8633-6C3745AC6F34".AsGuid(), null, "C2D29296-6A87-47A9-A753-EE4E9159C4C4".AsGuid(), "0AB2D5E9-9272-47D5-90E4-4AA838D2D3EE".AsGuid(), "Defined Value List - Status", "SectionD", @"", @"", 1, "362581DC-6224-40FA-B351-FC2572022166" );
 
             // update block order for pages with new blocks if the page,zone has multiple blocks
 
@@ -126,7 +126,7 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Minimum Care Touches", "MinimumCareTouches", "Minimum Care Touches", @"Minimum care touches in 'Minimum Care Touch Hours' before the need gets 'flagged'.", 3, @"2", "8291F010-FFFE-4806-8E19-E701FAC62E10" );
 
             // Attribute for BlockType: Care Dashboard:Minimum Care Touch Hours
-            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Minimum Care Touch Giyrs", "MinimumCareTouchHours", "Minimum Care Touch Hours", @"Minimum care touches in this time period before the need gets 'flagged'.", 3, @"24", "8945BE62-D065-4A19-89A8-B06CE51FFBFF" );
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Minimum Care Touch Givers", "MinimumCareTouchHours", "Minimum Care Touch Hours", @"Minimum care touches in this time period before the need gets 'flagged'.", 3, @"24", "8945BE62-D065-4A19-89A8-B06CE51FFBFF" );
 
             // Attribute for BlockType: Care Dashboard:Detail Page
             RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "BD53F9C9-EBA9-4D3F-82EA-DE5DD34A8108", "Detail Page", "DetailPage", "Detail Page", @"Page used to modify and create care needs.", 1, @"", "83441829-9BAA-4C9A-921B-E3DCED54BB20" );

--- a/rocks.kfs.StepsToCare/Migrations/010_AddParentNeedId.cs
+++ b/rocks.kfs.StepsToCare/Migrations/010_AddParentNeedId.cs
@@ -1,0 +1,45 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 10, "1.12.3" )]
+    public class AddParentNeedId : Migration
+    {
+        public override void Up()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] ADD [ParentNeedId] int NULL
+
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed]  WITH CHECK ADD  CONSTRAINT [FK__rocks_kfs_StepsToCare_CareNeed_ParentNeed] FOREIGN KEY([ParentNeedId])
+                REFERENCES [dbo].[_rocks_kfs_StepsToCare_CareNeed] ([Id])
+
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] CHECK CONSTRAINT [FK__rocks_kfs_StepsToCare_CareNeed_ParentNeed]
+            " );
+        }
+
+        public override void Down()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] DROP CONSTRAINT [FK__rocks_kfs_StepsToCare_CareNeed_ParentNeed]
+
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareNeed] DROP COLUMN [ParentNeedId]
+            " );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Migrations/011_AddWorkerColumns.cs
+++ b/rocks.kfs.StepsToCare/Migrations/011_AddWorkerColumns.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.StepsToCare/Migrations/011_AddWorkerColumns.cs
+++ b/rocks.kfs.StepsToCare/Migrations/011_AddWorkerColumns.cs
@@ -1,0 +1,42 @@
+﻿// <copyright>
+// Copyright 2021 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 11, "1.12.3" )]
+    public class AddWorkerColumns : Migration
+    {
+        public override void Up()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] ADD [AgeRangeMin] decimal(18,0) NULL
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] ADD [AgeRangeMax] decimal(18,0) NULL
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] ADD [Gender] int NULL
+            " );
+        }
+
+        public override void Down()
+        {
+            Sql( @"
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] DROP COLUMN [Gender]
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] DROP COLUMN [AgeRangeMax]
+                ALTER TABLE [dbo].[_rocks_kfs_StepsToCare_CareWorker] DROP COLUMN [AgeRangeMin]
+            " );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Migrations/012_NewBlockSettings.cs
+++ b/rocks.kfs.StepsToCare/Migrations/012_NewBlockSettings.cs
@@ -39,13 +39,13 @@ namespace rocks.kfs.StepsToCare.Migrations
             //   BlockType: Care Entry
             //   Category: KFS > Steps To Care
             //   Attribute: Load Balanced Workers assignment type
-            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Load Balanced Workers assignment type", "LoadBalanceWorkersType", "Load Balanced Workers assignment type", @"How should the auto assign worker load balancing work? Prioritize, it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. Exclusive, if there are workers with matching campus, category or other parameters it will only load balance between those workers.", 0, @"Prioritize", "CBC82754-CD05-4C45-873B-EC0689882A9F" );
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Load Balanced Workers assignment type", "LoadBalanceWorkersType", "Load Balanced Workers assignment type", @"How should the auto assign worker load balancing work? Default: Exclusive. ""Prioritize"", it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. ""Exclusive"", if there are workers with matching campus, category or other parameters it will only load balance between those workers.", 0, @"Exclusive", "CBC82754-CD05-4C45-873B-EC0689882A9F" );
 
             // Attribute for BlockType
             //   BlockType: Care Entry
             //   Category: KFS > Steps To Care
             //   Attribute: Adults in Family Worker Assignment
-            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Adults in Family Worker Assignment", "AdultFamilyWorkers", "Adults in Family Workers", @"How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).", 0, @"Normal", "6424654F-AF58-40A0-9AC0-331ACBABD4D5" );
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Adults in Family Worker Assignment", "AdultFamilyWorkers", "Adults in Family Workers", @"How should workers be assigned to spouses and other adults in the family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).", 0, @"Normal", "6424654F-AF58-40A0-9AC0-331ACBABD4D5" );
 
             // Add Block Attribute Value
             //   Block: Care Entry
@@ -72,7 +72,7 @@ namespace rocks.kfs.StepsToCare.Migrations
             //   Block Location: Page=Care Entry, Site=Rock RMS
             //   Attribute: Load Balanced Workers assignment type
             /*   Attribute Value: Prioritize */
-            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "CBC82754-CD05-4C45-873B-EC0689882A9F", @"Prioritize" );
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "CBC82754-CD05-4C45-873B-EC0689882A9F", @"Exclusive" );
 
             // Add Block Attribute Value
             //   Block: Care Entry

--- a/rocks.kfs.StepsToCare/Migrations/012_NewBlockSettings.cs
+++ b/rocks.kfs.StepsToCare/Migrations/012_NewBlockSettings.cs
@@ -1,0 +1,114 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 12, "1.12.3" )]
+    public class NewBlockSettings : Migration
+    {
+        public override void Up()
+        {
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Verbose Logging
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Verbose Logging", "VerboseLogging", "Verbose Logging", @"Enable verbose Logging to help in determining issues with adding needs or auto assigning workers. Not recommended for normal use.", 0, @"False", "549C11F0-F532-4B3D-99D8-DC79ECB36498" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Enable Family Needs
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Enable Family Needs", "EnableFamilyNeeds", "Enable Family Needs", @"Show a checkbox to 'Include Family' which will create duplicate Care Needs for each family member with their own workers.", 0, @"False", "19C5157F-43C8-47E6-A757-A3507FC960CB" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Load Balanced Workers assignment type
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Load Balanced Workers assignment type", "LoadBalanceWorkersType", "Load Balanced Workers assignment type", @"How should the auto assign worker load balancing work? Prioritize, it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. Exclusive, if there are workers with matching campus, category or other parameters it will only load balance between those workers.", 0, @"Prioritize", "CBC82754-CD05-4C45-873B-EC0689882A9F" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Adults in Family Worker Assignment
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Adults in Family Worker Assignment", "AdultFamilyWorkers", "Adults in Family Workers", @"How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).", 0, @"Normal", "6424654F-AF58-40A0-9AC0-331ACBABD4D5" );
+
+            // Add Block Attribute Value
+            //   Block: Care Entry
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Block Location: Page=Care Entry, Site=Rock RMS
+            //   Attribute: Verbose Logging
+            /*   Attribute Value: False */
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "549C11F0-F532-4B3D-99D8-DC79ECB36498", @"False" );
+
+            // Add Block Attribute Value
+            //   Block: Care Entry
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Block Location: Page=Care Entry, Site=Rock RMS
+            //   Attribute: Enable Family Needs
+            /*   Attribute Value: False */
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "19C5157F-43C8-47E6-A757-A3507FC960CB", @"False" );
+
+            // Add Block Attribute Value
+            //   Block: Care Entry
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Block Location: Page=Care Entry, Site=Rock RMS
+            //   Attribute: Load Balanced Workers assignment type
+            /*   Attribute Value: Prioritize */
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "CBC82754-CD05-4C45-873B-EC0689882A9F", @"Prioritize" );
+
+            // Add Block Attribute Value
+            //   Block: Care Entry
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Block Location: Page=Care Entry, Site=Rock RMS
+            //   Attribute: Adults in Family Worker Assignment
+            /*   Attribute Value: Normal */
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "6424654F-AF58-40A0-9AC0-331ACBABD4D5", @"Normal" );
+        }
+
+        public override void Down()
+        {
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Adults in Family Worker Assignment
+            RockMigrationHelper.DeleteAttribute( "6424654F-AF58-40A0-9AC0-331ACBABD4D5" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Load Balanced Workers assignment type
+            RockMigrationHelper.DeleteAttribute( "CBC82754-CD05-4C45-873B-EC0689882A9F" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Enable Family Needs
+            RockMigrationHelper.DeleteAttribute( "19C5157F-43C8-47E6-A757-A3507FC960CB" );
+
+            // Attribute for BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Verbose Logging
+            RockMigrationHelper.DeleteAttribute( "549C11F0-F532-4B3D-99D8-DC79ECB36498" );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Model/CareNeed.cs
+++ b/rocks.kfs.StepsToCare/Model/CareNeed.cs
@@ -175,6 +175,7 @@ namespace rocks.kfs.StepsToCare.Model
             this.HasOptional( cn => cn.Status ).WithMany().HasForeignKey( cn => cn.StatusValueId ).WillCascadeOnDelete( false );
             this.HasOptional( cn => cn.Category ).WithMany().HasForeignKey( cn => cn.CategoryValueId ).WillCascadeOnDelete( false );
             this.HasOptional( cn => cn.Campus ).WithMany().HasForeignKey( cn => cn.CampusId ).WillCascadeOnDelete( false );
+            // CascadeOnDelete is managed by a trigger that will set to null if parent need is deleted.
             this.HasOptional( cn => cn.ParentNeed ).WithMany( cn => cn.ChildNeeds ).HasForeignKey( cn => cn.ParentNeedId ).WillCascadeOnDelete( false );
 
             // IMPORTANT!!

--- a/rocks.kfs.StepsToCare/Model/CareNeed.cs
+++ b/rocks.kfs.StepsToCare/Model/CareNeed.cs
@@ -79,6 +79,9 @@ namespace rocks.kfs.StepsToCare.Model
         [DataMember]
         public bool WorkersOnly { get; set; }
 
+        [DataMember]
+        public int? ParentNeedId { get; set; }
+
         #endregion Entity Properties
 
         #region Virtual Properties
@@ -105,7 +108,13 @@ namespace rocks.kfs.StepsToCare.Model
         public virtual Campus Campus { get; set; }
 
         [LavaInclude]
+        public virtual CareNeed ParentNeed { get; set; }
+
+        [LavaInclude]
         public virtual ICollection<AssignedPerson> AssignedPersons { get; set; }
+
+        [LavaInclude]
+        public virtual ICollection<CareNeed> ChildNeeds { get; set; }
 
         #endregion Virtual Properties
 
@@ -166,7 +175,7 @@ namespace rocks.kfs.StepsToCare.Model
             this.HasOptional( cn => cn.Status ).WithMany().HasForeignKey( cn => cn.StatusValueId ).WillCascadeOnDelete( false );
             this.HasOptional( cn => cn.Category ).WithMany().HasForeignKey( cn => cn.CategoryValueId ).WillCascadeOnDelete( false );
             this.HasOptional( cn => cn.Campus ).WithMany().HasForeignKey( cn => cn.CampusId ).WillCascadeOnDelete( false );
-
+            this.HasOptional( cn => cn.ParentNeed ).WithMany( cn => cn.ChildNeeds ).HasForeignKey( cn => cn.ParentNeedId ).WillCascadeOnDelete( false );
 
             // IMPORTANT!!
             this.HasEntitySetName( "CareNeed" );

--- a/rocks.kfs.StepsToCare/Model/CareNeed.cs
+++ b/rocks.kfs.StepsToCare/Model/CareNeed.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.StepsToCare/Model/CareWorker.cs
+++ b/rocks.kfs.StepsToCare/Model/CareWorker.cs
@@ -60,6 +60,21 @@ namespace rocks.kfs.StepsToCare.Model
         [DataMember]
         public bool NotifyPush { get; set; }
 
+        [DataMember]
+        public decimal? AgeRangeMin { get; set; }
+
+        [DataMember]
+        public decimal? AgeRangeMax { get; set; }
+
+        /// <summary>
+        /// Gets or sets the gender of the people this Care Worker will be assigned to.
+        /// </summary>
+        /// <value>
+        /// A <see cref="Rock.Model.Gender"/> enum value representing the peoples gender assigned to this worker.  Valid values are <c>Gender.Unknown</c> if the gender should not be limited,
+        /// <c>Gender.Male</c> if the gender should be limited to Male, <c>Gender.Female</c> if the gender should be limited to Female.
+        /// </value>
+        [DataMember]
+        public Gender? Gender { get; set; }
         #endregion Entity Properties
 
         #region Virtual Properties

--- a/rocks.kfs.StepsToCare/Model/CareWorker.cs
+++ b/rocks.kfs.StepsToCare/Model/CareWorker.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.2.*" )]
+[assembly: AssemblyVersion( "1.3.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -73,6 +73,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
+    <Compile Include="Migrations\011_AddWorkerColumns.cs" />
+    <Compile Include="Migrations\010_AddParentNeedId.cs" />
     <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />
     <Compile Include="Migrations\009_CreatePermissions.cs" />
     <Compile Include="Migrations\008_LavaShortcode.cs" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
+    <Compile Include="Migrations\012_NewBlockSettings.cs" />
     <Compile Include="Migrations\011_AddWorkerColumns.cs" />
     <Compile Include="Migrations\010_AddParentNeedId.cs" />
     <Compile Include="Migrations\006_AddWorkersOnlyColumn.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added new columns to data model to support sub/family/parent needs. (ParentNeed/ParentNeedId/ChildNeeds)
- Added new criteria to workers for family needs. (Age Range and Gender)
- Fix a cascade permission on care workers and assigned person tables.

See [RockBlocks#95](https://github.com/KingdomFirst/RockBlocks/pull/95) for more information

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

See [RockBlocks#95](https://github.com/KingdomFirst/RockBlocks/pull/95) for more information

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

Not the assembly.

---------

### Change Log

##### What files does it affect?

- rocks.kfs.StepsToCare/Migrations/001_CreateDb.cs
- rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs
- rocks.kfs.StepsToCare/Migrations/010_AddParentNeedId.cs
- rocks.kfs.StepsToCare/Migrations/011_AddWorkerColumns.cs
- rocks.kfs.StepsToCare/Migrations/012_NewBlockSettings.cs
- rocks.kfs.StepsToCare/Model/CareNeed.cs
- rocks.kfs.StepsToCare/Model/CareWorker.cs
- rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
- rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
