### PR TITLE
Steps to Care Automated Notification Update

### DIFF
--- a/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
+++ b/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
@@ -285,7 +285,7 @@ namespace rocks.kfs.StepsToCare.Jobs
                         //var pushMessage = new RockPushMessage( careTouchNeededCommunication );
                         var recipients = new List<RockMessageRecipient>();
 
-                        foreach ( var assignee in careNeed.AssignedPersons )
+                        foreach ( var assignee in careNeed.AssignedPersons.Where( ap => ap.FollowUpWorker.HasValue && ap.FollowUpWorker.Value ) )
                         {
                             assignee.PersonAlias.Person.LoadAttributes();
 

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.3.*" )]
+[assembly: AssemblyVersion( "1.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Make it so the attention needed automated notification only goes to follow up workers instead of all assigned persons.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Make it so the attention needed automated notification only goes to follow up workers instead of all assigned persons.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
