### PR TITLE
Intacct Bug Fix - Handle Refund transaction fees

### DIFF
--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -228,7 +228,7 @@ namespace rocks.kfs.Intacct
                     Summary = summary,
                     CustomDimensions = customDimensions
                 };
-                Dictionary<string, object> mergeFields = TransactionHelpers.GetMergeFieldsAndDimensions(  ref debugLava, customDimensionValues, mergeFieldObjects );
+                Dictionary<string, object> mergeFields = TransactionHelpers.GetMergeFieldsAndDimensions( ref debugLava, customDimensionValues, mergeFieldObjects );
 
                 var batchSummaryItem = new GLBatchTotals()
                 {
@@ -258,7 +258,7 @@ namespace rocks.kfs.Intacct
             foreach ( var transaction in transactionItems )
             {
                 var processTransactionFees = 0;
-                if ( transaction.ProcessTransactionFees > 0 && !string.IsNullOrWhiteSpace( transaction.TransactionFeeAccount ) && transaction.TransactionFeeAmount > 0 )
+                if ( transaction.ProcessTransactionFees > 0 && !string.IsNullOrWhiteSpace( transaction.TransactionFeeAccount ) && ( transaction.TransactionFeeAmount > 0 || transaction.TransactionFeeAmount < 0 ) )
                 {
                     processTransactionFees = transaction.ProcessTransactionFees;
                 }

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.2.*" )]
+[assembly: AssemblyVersion( "2.3.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -113,7 +113,7 @@ namespace rocks.kfs.Intacct.Utils
                         Amount = transactionDetail.Amount,
                         FinancialAccountId = transactionDetail.AccountId,
                         Project = projectCode,
-                        TransactionFeeAmount = transactionDetail.FeeAmount != null && transactionDetail.FeeAmount.Value > 0 ? transactionDetail.FeeAmount.Value : 0.0M,
+                        TransactionFeeAmount = transactionDetail.FeeAmount != null && ( transactionDetail.FeeAmount.Value > 0 || transactionDetail.FeeAmount.Value < 0 ) ? transactionDetail.FeeAmount.Value : 0.0M,
                         TransactionFeeAccount = transactionFeeAccount,
                         ProcessTransactionFees = processTransactionFees
                     };


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Refund "transaction fees" were being ignored due to them coming in as negative amounts and our code only looking for FeeAmount > 0.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an issue with Intacct Export, when using Transaction Fee capability, refund transaction fees were being ignored.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

Before:   
<img width="551" alt="image" src="https://user-images.githubusercontent.com/2990519/177652021-9de76f9e-ce8d-46c0-946d-cb461e371f8b.png">

After:   
<img width="550" alt="image" src="https://user-images.githubusercontent.com/2990519/177652064-a9ba9b9e-fdf9-4c45-a6f3-86ff3cdba473.png">


---------

### Change Log

##### What files does it affect?

- rocks.kfs.Intacct/IntacctJournal.cs
- rocks.kfs.Intacct/Properties/AssemblyInfo.cs
- rocks.kfs.Intacct/Utils/TransactionHelpers.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
