### PR TITLE
Steps to Care Future Needs

### DIFF
--- a/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
+++ b/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
@@ -156,7 +156,7 @@ namespace rocks.kfs.StepsToCare.Jobs
 
         private static class CategoryKey
         {
-            public const string FutureNeedAssignments = "FutureNeedAssignments";
+            public const string FutureNeedAssignments = "Future Need Assignments";
         }
 
         private int assignedPersonEmails = 0;

--- a/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
+++ b/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
@@ -117,7 +117,7 @@ namespace rocks.kfs.StepsToCare.Jobs
         Category = CategoryKey.FutureNeedAssignments )]
 
     [IntegerField( "Threshold of Days before Assignment",
-        Description = "The number of days you can schedule a need in the future before a need will be assigned to workers.",
+        Description = "The number of days before a scheduled need is assigned to workers. Default: 3",
         IsRequired = true,
         DefaultIntegerValue = 3,
         Key = AttributeKey.FutureThresholdDays,

--- a/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedProcesses.cs
+++ b/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedProcesses.cs
@@ -129,7 +129,7 @@ namespace rocks.kfs.StepsToCare.Jobs
         Key = AttributeKey.VerboseLogging )]
 
     [DisallowConcurrentExecution]
-    public class CareNeedAutomatedNotifications : IJob
+    public class CareNeedAutomatedProcesses : IJob
     {
         /// <summary>
         /// Attribute Keys
@@ -168,7 +168,7 @@ namespace rocks.kfs.StepsToCare.Jobs
         /// <summary>
         /// Initializes a new instance of the <see cref="SendCommunications"/> class.
         /// </summary>
-        public CareNeedAutomatedNotifications()
+        public CareNeedAutomatedProcesses()
         {
         }
 

--- a/rocks.kfs.StepsToCare/Migrations/015_UpdateJob.cs
+++ b/rocks.kfs.StepsToCare/Migrations/015_UpdateJob.cs
@@ -1,0 +1,115 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock;
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 15, "1.12.3" )]
+    public class UpdateJob : Migration
+    {
+        public override void Up()
+        {
+            Sql( @"IF EXISTS( SELECT [Id] FROM [ServiceJob] WHERE [Class] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' AND [Guid] = '895C301C-02D1-4D9C-9FC4-DA7257368208' )
+            BEGIN
+               UPDATE [ServiceJob]
+                SET
+                    [Name] = 'Care Need Automated Processes'
+                  , [Class] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses'
+                WHERE
+                    [Guid] = '895C301C-02D1-4D9C-9FC4-DA7257368208'
+            END" );
+
+            Sql( @"UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = '125F5EB3-8223-40B9-8FD6-4EED93602D72'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = '8D050C0F-105B-4A8B-8879-A15F78F5913E'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = '08D1BB81-9FCA-488B-9383-9440D1DCCFC6'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = 'A29278C1-9A80-4BEA-81A9-1B7FCB6CA305'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = 'F64479EE-A595-4AA3-97D6-CAA768464284'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = '5D8548E7-9570-4337-888B-A51868A57CD0'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = '245DFE71-FF8D-41FE-91A8-E4D29B1AF016'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' WHERE [Guid] = 'AF3ECA88-C715-4E2D-9D9B-C4CC3141C6EC'" );
+
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Group Type and Role
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "3BB25568-E793-4D12-AE80-AC3FDA6FD8A8", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Group Type and Role", "Group Type and Role", @"Select the group Type and Role of the leader you would like auto assigned to care need. If none are selected it will not auto assign the small group member to the need. ", 0, @"", "D3F19DE8-B8A0-4B87-AB4D-DE827D79C780", "GroupTypeAndRole" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Auto Assign Worker with Geofence
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Auto Assign Worker with Geofence", "Auto Assign Worker with Geofence", @"Care Need Workers can have Geofence locations assigned to them, if there are workers with geofences and this block setting is enabled it will auto assign workers to this need on new entries based on the requester home being in the geofence.", 0, @"True", "54E062CE-BBA1-4C65-A12D-1774A145930D", "AutoAssignWorkerGeofence" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Auto Assign Worker (load balanced)
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Auto Assign Worker (load balanced)", "Auto Assign Worker (load balanced)", @"Use intelligent load balancing to auto assign care workers to a care need based on their workload and other parameters?", 0, @"True", "1FDE9E0C-D98A-4CB1-BABD-EA294F76653A", "AutoAssignWorker" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Newly Assigned Need Notification
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "72ED40C7-4D64-4D60-9411-4FFB2B9E833E", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Newly Assigned Need Notification", "Newly Assigned Need Notification", @"Select the system communication template for the new assignment notification.", 0, @"70CF2049-A443-4C87-82C3-0A8A22D8DAC8", "AC8DB5F1-1BF8-4AC0-B1CD-D0A28E850343", "NewAssignmentNotification" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Load Balanced Workers assignment type
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Load Balanced Workers assignment type", "Load Balanced Workers assignment type", @"How should the auto assign worker load balancing work? Default: Exclusive. ""Prioritize"", it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. ""Exclusive"", if there are workers with matching campus, category or other parameters it will only load balance between those workers.", 0, @"Exclusive", "9A6C8A35-5197-4CBA-9BE6-5A9CAFF6A469", "LoadBalanceWorkersType" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Adults in Family Worker Assignment
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "7525C4CB-EE6B-41D4-9B64-A08048D5A5C0", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Adults in Family Worker Assignment", "Adults in Family Worker Assignment", @"How should workers be assigned to spouses and other adults in the family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).", 0, @"Normal", "33649C3E-F221-4562-BCA1-B775127097C8", "AdultFamilyWorkers" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Threshold of Days before Assignment
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Threshold of Days before Assignment", "Threshold of Days before Assignment", @"The number of days you can schedule a need in the future before a need will be assigned to workers.", 0, @"3", "D98AECCE-07D9-46A6-8401-6DE8615143F2", "FutureThresholdDays" );
+            // Attribute: rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Verbose Logging
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Verbose Logging", "Verbose Logging", @"Enable verbose Logging to help in determining issues with adding needs or auto assigning workers. Not recommended for normal use.", 0, @"False", "37CEC870-6B09-4231-ACC8-DEE0CAB55466", "VerboseLogging" );
+
+            RockMigrationHelper.AddAttributeValue( "AC8DB5F1-1BF8-4AC0-B1CD-D0A28E850343", -1, SystemGuid.SystemCommunication.CARE_NEED_ASSIGNED, "AC8DB5F1-1BF8-4AC0-B1CD-D0A28E850343" ); // Care Need Automated Notifications: Newly Assigned Need Notification
+            RockMigrationHelper.AddAttributeValue( "D3F19DE8-B8A0-4B87-AB4D-DE827D79C780", -1, @"6d798efa-0110-41d5-bce4-30acefe4317e", "D3F19DE8-B8A0-4B87-AB4D-DE827D79C780" ); // Care Need Automated Notifications: Group Type and Role
+            RockMigrationHelper.AddAttributeValue( "54E062CE-BBA1-4C65-A12D-1774A145930D", -1, @"True", "54E062CE-BBA1-4C65-A12D-1774A145930D" ); // Care Need Automated Notifications: Auto Assign Worker with Geofence
+            RockMigrationHelper.AddAttributeValue( "1FDE9E0C-D98A-4CB1-BABD-EA294F76653A", -1, @"True", "1FDE9E0C-D98A-4CB1-BABD-EA294F76653A" ); // Care Need Automated Notifications: Auto Assign Worker (load balanced)
+            RockMigrationHelper.AddAttributeValue( "9A6C8A35-5197-4CBA-9BE6-5A9CAFF6A469", -1, @"Exclusive", "9A6C8A35-5197-4CBA-9BE6-5A9CAFF6A469" ); // Care Need Automated Notifications: Load Balanced Workers assignment type
+            RockMigrationHelper.AddAttributeValue( "33649C3E-F221-4562-BCA1-B775127097C8", -1, @"Normal", "33649C3E-F221-4562-BCA1-B775127097C8" ); // Care Need Automated Notifications: Adults in Family Worker Assignment
+            RockMigrationHelper.AddAttributeValue( "D98AECCE-07D9-46A6-8401-6DE8615143F2", -1, @"3", "D98AECCE-07D9-46A6-8401-6DE8615143F2" ); // Care Need Automated Notifications: Threshold of Days before Assignment
+            RockMigrationHelper.AddAttributeValue( "37CEC870-6B09-4231-ACC8-DEE0CAB55466", -1, @"False", "37CEC870-6B09-4231-ACC8-DEE0CAB55466" ); // Care Need Automated Notifications: Verbose Logging
+
+            Sql( @"DECLARE @JobId int = ( SELECT TOP 1 [Id] FROM [ServiceJob] WHERE [Guid] = '895C301C-02D1-4D9C-9FC4-DA7257368208' )
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = 'AC8DB5F1-1BF8-4AC0-B1CD-D0A28E850343'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = 'D3F19DE8-B8A0-4B87-AB4D-DE827D79C780'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = '54E062CE-BBA1-4C65-A12D-1774A145930D'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = '1FDE9E0C-D98A-4CB1-BABD-EA294F76653A'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = '9A6C8A35-5197-4CBA-9BE6-5A9CAFF6A469'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = '33649C3E-F221-4562-BCA1-B775127097C8'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = 'D98AECCE-07D9-46A6-8401-6DE8615143F2'
+                 UPDATE [AttributeValue] SET EntityId = @JobId WHERE [Guid] = '37CEC870-6B09-4231-ACC8-DEE0CAB55466'" ); // Set EntityId to proper Job id
+
+        }
+
+        public override void Down()
+        {
+            Sql( @"IF EXISTS( SELECT [Id] FROM [ServiceJob] WHERE [Class] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses' AND [Guid] = '895C301C-02D1-4D9C-9FC4-DA7257368208' )
+            BEGIN
+               UPDATE [ServiceJob]
+                SET
+                    [Name] = 'Care Need Automated Notifications'
+                  , [Class] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications'
+                WHERE
+                    [Guid] = '895C301C-02D1-4D9C-9FC4-DA7257368208'
+            END" );
+
+            RockMigrationHelper.DeleteAttribute( "D3F19DE8-B8A0-4B87-AB4D-DE827D79C780" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Group Type and Role
+            RockMigrationHelper.DeleteAttribute( "54E062CE-BBA1-4C65-A12D-1774A145930D" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Auto Assign Worker with Geofence
+            RockMigrationHelper.DeleteAttribute( "1FDE9E0C-D98A-4CB1-BABD-EA294F76653A" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Auto Assign Worker (load balanced)
+            RockMigrationHelper.DeleteAttribute( "AC8DB5F1-1BF8-4AC0-B1CD-D0A28E850343" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Newly Assigned Need Notification
+            RockMigrationHelper.DeleteAttribute( "9A6C8A35-5197-4CBA-9BE6-5A9CAFF6A469" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Load Balanced Workers assignment type
+            RockMigrationHelper.DeleteAttribute( "33649C3E-F221-4562-BCA1-B775127097C8" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Adults in Family Worker Assignment
+            RockMigrationHelper.DeleteAttribute( "D98AECCE-07D9-46A6-8401-6DE8615143F2" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Threshold of Days before Assignment
+            RockMigrationHelper.DeleteAttribute( "37CEC870-6B09-4231-ACC8-DEE0CAB55466" ); // rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications: Verbose Logging
+
+            Sql( @"UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = '125F5EB3-8223-40B9-8FD6-4EED93602D72'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = '8D050C0F-105B-4A8B-8879-A15F78F5913E'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = '08D1BB81-9FCA-488B-9383-9440D1DCCFC6'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = 'A29278C1-9A80-4BEA-81A9-1B7FCB6CA305'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = 'F64479EE-A595-4AA3-97D6-CAA768464284'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = '5D8548E7-9570-4337-888B-A51868A57CD0'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = '245DFE71-FF8D-41FE-91A8-E4D29B1AF016'
+                   UPDATE [Attribute] SET [EntityTypeQualifierValue] = 'rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications' WHERE [Guid] = 'AF3ECA88-C715-4E2D-9D9B-C4CC3141C6EC'" );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Model/WorkerResult.cs
+++ b/rocks.kfs.StepsToCare/Model/WorkerResult.cs
@@ -1,0 +1,12 @@
+﻿namespace rocks.kfs.StepsToCare.Model
+{
+    public partial class WorkerResult
+    {
+        public int Count { get; set; }
+        public CareWorker Worker { get; set; }
+        public bool HasCategory { get; set; } = false;
+        public bool HasCampus { get; set; } = false;
+        public bool HasAgeRange { get; set; } = false;
+        public bool HasGender { get; set; } = false;
+    }
+}

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.4.*" )]
+[assembly: AssemblyVersion( "1.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -1,0 +1,619 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using NuGet;
+using Rock;
+using Rock.Communication;
+using Rock.Data;
+using Rock.Logging;
+using Rock.Model;
+using Rock.Web;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+using rocks.kfs.StepsToCare.Model;
+
+namespace rocks.kfs.StepsToCare
+{
+    public class CareUtilities
+    {
+        public static void AutoAssignWorkers( CareNeed careNeed, bool roundRobinOnly = false, bool childAssignment = false, bool autoAssignWorker = false, bool autoAssignWorkerGeofence = false, string loadBalanceType = "Exclusive", Guid leaderRoleGuid = new Guid(), bool enableLogging = false )
+        {
+            var rockContext = new RockContext();
+
+            var careNeedService = new CareNeedService( rockContext );
+            var careWorkerService = new CareWorkerService( rockContext );
+            var careAssigneeService = new AssignedPersonService( rockContext );
+
+            // reload careNeed to fully populate child properties
+            careNeed = careNeedService.Get( careNeed.Guid );
+
+            var careWorkers = careWorkerService.Queryable().AsNoTracking().Where( cw => cw.IsActive );
+
+            var addedWorkerAliasIds = new List<int?>();
+
+            // auto assign Deacon/Worker by Geofence
+            if ( autoAssignWorkerGeofence && !roundRobinOnly )
+            {
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, CareWorkers Count: {1}", careNeed.Guid, careWorkers.Count() ), "Geofence assignment start." );
+                }
+                var careWorkersWithFence = careWorkers.Where( cw => cw.GeoFenceId != null );
+                foreach ( var worker in careWorkersWithFence )
+                {
+                    var geofenceLocation = new LocationService( rockContext ).Get( worker.GeoFenceId.Value );
+                    if ( enableLogging )
+                    {
+                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceLocation: {1}", careNeed.Guid, geofenceLocation.Id ), "Care Workers with Fence" );
+                    }
+                    var homeLocation = careNeed.PersonAlias.Person.GetHomeLocation();
+                    if ( enableLogging )
+                    {
+                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceLocation: {1}, homeLocation: {2}", careNeed.Guid, geofenceLocation.Id, ( homeLocation != null ) ? homeLocation.Id.ToString() : "null" ), "Care Workers with Fence" );
+                    }
+                    if ( homeLocation != null && homeLocation.GeoPoint != null )
+                    {
+                        var geofenceIntersect = homeLocation.GeoPoint.Intersects( geofenceLocation.GeoFence );
+                        if ( enableLogging )
+                        {
+                            LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceIntersect: {1}, homeLocation: {2}", careNeed.Guid, geofenceIntersect, homeLocation.Id ), "geofenceIntersect" );
+                        }
+                        if ( geofenceIntersect )
+                        {
+                            var careAssignee = new AssignedPerson { Id = 0 };
+                            careAssignee.CareNeed = careNeed;
+                            careAssignee.PersonAliasId = worker.PersonAliasId;
+                            careAssignee.WorkerId = worker.Id;
+                            //careAssignee.FollowUpWorker = true;
+
+                            careAssigneeService.Add( careAssignee );
+                            addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+                        }
+                    }
+                    else if ( homeLocation != null && homeLocation.GeoPoint == null )
+                    {
+                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Id: {0}, homeLocation: {1}", careNeed.Id, homeLocation.Id ), "Home Location does not have a valid GeoPoint. Please verify their address and manually assign their geo worker." );
+                    }
+                }
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkersWithFence Count: {1} addedWorkerAliasIds Count: {2}", careNeed.Guid, careWorkersWithFence.Count(), addedWorkerAliasIds.Count() ), "Geofence assignment end." );
+                }
+            }
+
+            //auto assign worker/pastor by load balance assignment
+            if ( autoAssignWorker )
+            {
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, CareWorkers Count: {1}", careNeed.Guid, careWorkers.Count() ), "Auto Assign Worker start." );
+                }
+                var careWorkersNoFence = careWorkers.Where( cw => cw.GeoFenceId == null );
+                var workerAssigned = false;
+                var closedId = DefinedValueCache.Get( rocks.kfs.StepsToCare.SystemGuid.DefinedValue.CARE_NEED_STATUS_CLOSED ).Id;
+
+                // Campus, Category, Ignore Age Range and Gender
+                var careWorkerCount1 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, true, true );
+
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkersNoFence Count: {1}, careWorkerCount1 Count: {2}", careNeed.Guid, careWorkersNoFence.Count(), careWorkerCount1.Count() ), "careWorkerCount1, Category AND Campus" );
+                }
+
+                // Category, Ignore Age Range and Gender
+                var careWorkerCount2 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, true, true );
+
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount2 Count: {1}", careNeed.Guid, careWorkerCount2.Count() ), "careWorkerCount2, Category NOT Campus" );
+                }
+
+                // Campus, Ignore Age Range and Gender
+                var careWorkerCount3 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, false, true );
+
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount3 Count: {1}", careNeed.Guid, careWorkerCount3.Count() ), "careWorkerCount3, Campus NOT Category" );
+                }
+
+                // None, doesn't include parameters for other values though.
+                var careWorkerCount4 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, false, true );
+
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount4 Count: {1}", careNeed.Guid, careWorkerCount4.Count() ), "careWorkerCount4, NOT Campus or Category" );
+                }
+
+                IOrderedQueryable<WorkerResult> careWorkersCountChild1 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild2 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild3 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild4 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild5 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild6 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild7 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild8 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild9 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild10 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild11 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild12 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild13 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild14 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild15 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild16 = null;
+                if ( childAssignment )
+                {
+                    // AgeRange, Gender, Campus, Category
+                    careWorkersCountChild1 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, true );
+
+                    // AgeRange, Gender, Category
+                    careWorkersCountChild2 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, true );
+
+                    // AgeRange, Gender, Campus
+                    careWorkersCountChild3 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, false );
+
+                    // AgeRange, Campus, Category
+                    careWorkersCountChild4 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, true );
+
+                    // Gender, Campus, Category
+                    careWorkersCountChild5 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, true );
+
+                    // AgeRange, Gender
+                    careWorkersCountChild6 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, false );
+
+                    // AgeRange, Category
+                    careWorkersCountChild7 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, true );
+
+                    // AgeRange, Campus
+                    careWorkersCountChild8 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, false );
+
+                    // Gender, Category
+                    careWorkersCountChild9 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, true );
+
+                    // Gender, Campus
+                    careWorkersCountChild10 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, false );
+
+                    // Campus, Category
+                    careWorkersCountChild11 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, true );
+
+                    // AgeRange
+                    careWorkersCountChild12 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, false );
+
+                    // Gender 
+                    careWorkersCountChild13 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, false );
+
+                    // Category
+                    careWorkersCountChild14 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, true );
+
+                    // Campus
+                    careWorkersCountChild15 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, false );
+
+                    // None
+                    careWorkersCountChild16 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, false );
+
+                }
+
+                var careWorkerCounts = careWorkerCount1;
+                if ( loadBalanceType == "Prioritize" )
+                {
+                    if ( childAssignment )
+                    {
+                        careWorkerCounts = careWorkersCountChild1
+                                            .Concat( careWorkersCountChild2 )
+                                            .Concat( careWorkersCountChild3 )
+                                            .Concat( careWorkersCountChild4 )
+                                            .Concat( careWorkersCountChild5 )
+                                            .Concat( careWorkersCountChild6 )
+                                            .Concat( careWorkersCountChild7 )
+                                            .Concat( careWorkersCountChild8 )
+                                            .Concat( careWorkersCountChild9 )
+                                            .Concat( careWorkersCountChild10 )
+                                            .Concat( careWorkersCountChild11 )
+                                            .Concat( careWorkersCountChild12 )
+                                            .Concat( careWorkersCountChild13 )
+                                            .Concat( careWorkersCountChild14 )
+                                            .Concat( careWorkersCountChild15 )
+                                            .Concat( careWorkersCountChild16 )
+                                            .OrderBy( ct => ct.Count )
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )         // AgeRange, Gender, Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )        // AgeRange, Gender, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )        // AgeRange, Gender, Campus
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )        // AgeRange, Campus, Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )        // Gender, Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )       // AgeRange, Gender
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )       // AgeRange, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )       // AgeRange, Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )       // Gender, Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )       // Gender, Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )       // Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // AgeRange
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // Gender
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )      // Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )      // Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory );    // None
+                    }
+                    else
+                    {
+                        careWorkerCounts = careWorkerCount1
+                                        .Concat( careWorkerCount2 )
+                                        .Concat( careWorkerCount3 )
+                                        .Concat( careWorkerCount4 )
+                                        .OrderBy( ct => ct.Count )
+                                        .ThenByDescending( ct => ct.HasCategory && ct.HasCampus )
+                                        .ThenByDescending( ct => ct.HasCategory && !ct.HasCampus )
+                                        .ThenByDescending( ct => ct.HasCampus && !ct.HasCategory );
+                    }
+                }
+                else
+                {
+                    if ( childAssignment )
+                    {
+                        if ( careWorkersCountChild1.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild1;
+                        }
+                        else if ( careWorkersCountChild2.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild2;
+                        }
+                        else if ( careWorkersCountChild3.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild3;
+                        }
+                        else if ( careWorkersCountChild4.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild4;
+                        }
+                        else if ( careWorkersCountChild5.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild5;
+                        }
+                        else if ( careWorkersCountChild6.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild6;
+                        }
+                        else if ( careWorkersCountChild7.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild7;
+                        }
+                        else if ( careWorkersCountChild8.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild8;
+                        }
+                        else if ( careWorkersCountChild9.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild9;
+                        }
+                        else if ( careWorkersCountChild10.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild10;
+                        }
+                        else if ( careWorkersCountChild11.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild11;
+                        }
+                        else if ( careWorkersCountChild12.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild12;
+                        }
+                        else if ( careWorkersCountChild13.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild13;
+                        }
+                        else if ( careWorkersCountChild14.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild14;
+                        }
+                        else if ( careWorkersCountChild15.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild15;
+                        }
+                        else if ( careWorkersCountChild16.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild16;
+                        }
+                    }
+                    else
+                    {
+                        if ( careWorkerCount1.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount1;
+                        }
+                        else if ( careWorkerCount2.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount2;
+                        }
+                        else if ( careWorkerCount3.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount3;
+                        }
+                        else if ( careWorkerCount4.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount4;
+                        }
+                    }
+                }
+
+                if ( enableLogging )
+                {
+                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCounts Count: {1}", careNeed.Guid, careWorkerCounts.Count() ), "Combined careWorkerCounts" );
+                }
+
+                foreach ( var workerCount in careWorkerCounts )
+                {
+                    var worker = workerCount.Worker;
+                    if ( !workerAssigned && !addedWorkerAliasIds.Contains( worker.PersonAliasId ) && worker.PersonAlias != null && careAssigneeService.GetByPersonAliasAndCareNeed( worker.PersonAlias.Id, careNeed.Id ) == null )
+                    {
+                        var careAssignee = new AssignedPerson { Id = 0 };
+                        careAssignee.CareNeed = careNeed;
+                        careAssignee.PersonAliasId = worker.PersonAliasId;
+                        careAssignee.WorkerId = worker.Id;
+                        careAssignee.FollowUpWorker = true;
+
+                        careAssigneeService.Add( careAssignee );
+                        addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+
+                        workerAssigned = true;
+
+                        if ( enableLogging )
+                        {
+                            LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, Worker PersonAliasId: {1}, WorkerId: {2}", careNeed.Guid, worker.PersonAliasId, worker.Id ), "Worker Assigned" );
+                        }
+                    }
+                }
+            }
+
+            // auto assign Small Group Leader by Role
+            //var leaderRoleGuid = GetAttributeValue( AttributeKey.GroupTypeAndRole ).AsGuidOrNull() ?? Guid.Empty;
+            var leaderRole = new GroupTypeRoleService( rockContext ).Get( leaderRoleGuid );
+            if ( enableLogging )
+            {
+                LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, Leader Role Guid: {1}, Leader Role: {2}", careNeed.Guid, leaderRoleGuid, leaderRole.Id ), "Get Leader Role" );
+            }
+
+            if ( leaderRole != null && !roundRobinOnly )
+            {
+                var groupMemberService = new GroupMemberService( rockContext );
+                var inGroups = groupMemberService.GetByPersonId( careNeed.PersonAlias.PersonId ).Where( gm => gm.Group != null && gm.Group.IsActive && !gm.Group.IsArchived && gm.Group.GroupTypeId == leaderRole.GroupTypeId && !gm.IsArchived && gm.GroupMemberStatus == GroupMemberStatus.Active ).Select( gm => gm.GroupId );
+
+                if ( inGroups.Any() )
+                {
+                    if ( enableLogging )
+                    {
+                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, In Groups Count: {1}, leaderRole.GroupTypeId: {2}", careNeed.Guid, inGroups.Count(), leaderRole.GroupTypeId ), "In Small Groups" );
+                    }
+                    var groupLeaders = groupMemberService.GetByGroupRoleId( leaderRole.Id ).Where( gm => inGroups.Contains( gm.GroupId ) && !gm.IsArchived && gm.GroupMemberStatus == GroupMemberStatus.Active );
+                    foreach ( var member in groupLeaders )
+                    {
+                        if ( !addedWorkerAliasIds.Contains( member.Person.PrimaryAliasId ) && careAssigneeService.GetByPersonAliasAndCareNeed( member.Person.PrimaryAliasId, careNeed.Id ) == null && member.PersonId != careNeed.PersonAlias.Person.Id )
+                        {
+                            var careAssignee = new AssignedPerson { Id = 0 };
+                            careAssignee.CareNeed = careNeed;
+                            careAssignee.PersonAliasId = member.Person.PrimaryAliasId;
+
+                            careAssigneeService.Add( careAssignee );
+                            addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+                        }
+                    }
+                    if ( enableLogging )
+                    {
+                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, groupLeaders Count: {1} addedWorkerAliasIds Count: {2}", careNeed.Guid, groupLeaders.Count(), addedWorkerAliasIds.Count() ), "In Small Groups, Leader Count" );
+                    }
+
+                }
+            }
+            rockContext.SaveChanges();
+        }
+
+        public static void SendWorkerNotification( RockContext rockContext, CareNeed careNeed, bool isNew, List<AssignedPerson> newlyAssignedPersons, Guid? assignmentEmailTemplateGuid, RockPage rockPage = null, string detailPagePath = "", string dashboardPagePath = "", Person person = null )
+        {
+            if ( rockContext == null )
+            {
+                rockContext = new RockContext();
+            }
+
+            var assignedPersons = careNeed.AssignedPersons;
+            if ( newlyAssignedPersons.Any() )
+            {
+                assignedPersons = newlyAssignedPersons;
+            }
+            else
+            {
+                // Reload Care Need after save changes
+                careNeed = new CareNeedService( new RockContext() ).Get( careNeed.Id );
+                assignedPersons = careNeed.AssignedPersons;
+                if ( careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
+                {
+                    foreach ( var need in careNeed.ChildNeeds )
+                    {
+                        assignedPersons.AddRange( need.AssignedPersons );
+                    }
+                }
+            }
+
+            if ( assignedPersons != null && assignedPersons.Any() && assignmentEmailTemplateGuid.HasValue && ( isNew || newlyAssignedPersons.Any() ) )
+            {
+                var errors = new List<string>();
+                var errorsSms = new List<string>();
+                Dictionary<string, object> linkedPages = new Dictionary<string, object>();
+                linkedPages.Add( "CareDetail", ( rockPage != null ) ? rockPage.PageReference.BuildUrl() : detailPagePath );
+                linkedPages.Add( "CareDashboard", ( rockPage != null ) ? GetParentPage( rockPage.PageId ).BuildUrl() : dashboardPagePath );
+
+                var systemCommunication = new SystemCommunicationService( rockContext ).Get( assignmentEmailTemplateGuid.Value );
+                var emailMessage = new RockEmailMessage( systemCommunication );
+                var smsMessage = new RockSMSMessage( systemCommunication );
+                if ( rockPage != null )
+                {
+                    emailMessage.AppRoot = smsMessage.AppRoot = rockPage.ResolveRockUrl( "~/" );
+                    emailMessage.ThemeRoot = smsMessage.ThemeRoot = rockPage.ResolveRockUrl( "~~/" );
+                }
+                foreach ( var assignee in assignedPersons )
+                {
+                    assignee.PersonAlias.Person.LoadAttributes();
+                    var smsNumber = assignee.PersonAlias.Person.PhoneNumbers.GetFirstSmsNumber();
+                    if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) && smsNumber.IsNullOrWhiteSpace() )
+                    {
+                        continue;
+                    }
+
+                    var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( rockPage, ( rockPage != null ) ? rockPage.CurrentPerson : person );
+                    mergeFields.Add( "CareNeed", careNeed );
+                    mergeFields.Add( "LinkedPages", linkedPages );
+                    mergeFields.Add( "AssignedPerson", assignee );
+                    mergeFields.Add( "Person", assignee.PersonAlias.Person );
+
+                    var notificationType = assignee.PersonAlias.Person.GetAttributeValue( rocks.kfs.StepsToCare.SystemGuid.PersonAttribute.NOTIFICATION.AsGuid() );
+
+                    if ( notificationType == null || notificationType == "Email" || notificationType == "Both" )
+                    {
+                        if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) )
+                        {
+                            var emailWarningMessage = string.Format( "{0} does not have a valid email address.", assignee.PersonAlias.Person.FullName );
+                            RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", emailWarningMessage );
+                            errors.Add( emailWarningMessage );
+                        }
+                        else
+                        {
+                            emailMessage.AddRecipient( new RockEmailMessageRecipient( assignee.PersonAlias.Person, mergeFields ) );
+                        }
+                    }
+
+                    if ( notificationType == "SMS" || notificationType == "Both" )
+                    {
+                        if ( string.IsNullOrWhiteSpace( smsNumber ) )
+                        {
+                            var smsWarningMessage = string.Format( "No SMS number could be found for {0}.", assignee.PersonAlias.Person.FullName );
+                            RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", smsWarningMessage );
+                            errorsSms.Add( smsWarningMessage );
+                        }
+
+                        smsMessage.AddRecipient( new RockSMSMessageRecipient( assignee.PersonAlias.Person, smsNumber, mergeFields ) );
+                    }
+                }
+                if ( emailMessage.GetRecipients().Count > 0 )
+                {
+                    emailMessage.Send( out errors );
+                }
+                if ( smsMessage.GetRecipients().Count > 0 )
+                {
+                    smsMessage.Send( out errorsSms );
+                }
+
+                if ( errors.Any() || errorsSms.Any() )
+                {
+                    StringBuilder sb = new StringBuilder();
+                    sb.Append( string.Format( "{0} Errors Sending Care Assignment Notification: ", errors.Count + errorsSms.Count ) );
+                    errors.ForEach( es => { sb.AppendLine(); sb.Append( es ); } );
+                    errorsSms.ForEach( es => { sb.AppendLine(); sb.Append( es ); } );
+                    string errorStr = sb.ToString();
+                    var exception = new Exception( errorStr );
+                    HttpContext context = HttpContext.Current;
+                    ExceptionLogService.LogException( exception, context );
+                }
+            }
+        }
+
+        private static IOrderedQueryable<WorkerResult> GenerateAgeQuery( CareNeed careNeed, IQueryable<CareWorker> careWorkersNoFence, int closedId, bool includeAgeRange, bool includeGender, bool includeCampus, bool includeCategory, bool ignoreAgeRangeAndGender = false )
+        {
+            var ageAsDecimal = ( decimal? ) careNeed.PersonAlias.Person.AgePrecise;
+            var tempQuery = careWorkersNoFence;
+
+            if ( includeAgeRange )
+            {
+                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && (
+                                                    ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
+                                                    ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
+                                                    ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
+                                                   )
+                                            );
+            }
+            else if ( !ignoreAgeRangeAndGender )
+            {
+                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && !(
+                                                     ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
+                                                     ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
+                                                     ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
+                                                    )
+                                            );
+            }
+
+            if ( includeGender )
+            {
+                tempQuery = tempQuery.Where( cw => cw.Gender == careNeed.PersonAlias.Person.Gender );
+            }
+            else if ( !ignoreAgeRangeAndGender )
+            {
+                tempQuery = tempQuery.Where( cw => cw.Gender != careNeed.PersonAlias.Person.Gender );
+            }
+
+            if ( includeCategory )
+            {
+                tempQuery = tempQuery.Where( cw => cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => !cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
+            }
+
+            if ( includeCampus )
+            {
+                tempQuery = tempQuery.Where( cw => cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => !cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
+            }
+
+            return tempQuery.Select( cw => new WorkerResult
+            {
+                Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
+                Worker = cw,
+                HasCategory = includeCategory,
+                HasCampus = includeCampus,
+                HasAgeRange = includeAgeRange,
+                HasGender = includeGender
+            }
+                                    )
+                                    .OrderBy( cw => cw.Count )
+                                    .ThenBy( cw => cw.Worker.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) )
+                                    .ThenBy( cw => cw.Worker.Campuses.Contains( careNeed.CampusId.ToString() ) );
+        }
+        private static PageReference GetParentPage( int pageId )
+        {
+            var pageCache = PageCache.Get( pageId );
+            if ( pageCache != null )
+            {
+                var parentPage = pageCache.ParentPage;
+                if ( parentPage != null )
+                {
+                    return new PageReference( parentPage.Guid.ToString() );
+                }
+            }
+            return new PageReference( pageCache.Guid.ToString() );
+        }
+        private static ServiceLog LogEvent( RockContext rockContext, string type, string input, string result )
+        {
+            if ( rockContext == null )
+            {
+                rockContext = new RockContext();
+            }
+
+            var rockLogger = new ServiceLogService( rockContext );
+            ServiceLog serviceLog = new ServiceLog
+            {
+                Name = "Steps To Care",
+                Type = type,
+                LogDateTime = RockDateTime.Now,
+                Input = input,
+                Result = result,
+                Success = true
+            };
+            rockLogger.Add( serviceLog );
+            rockContext.SaveChanges();
+            return serviceLog;
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -44,6 +44,10 @@
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions">
       <HintPath>..\..\RockWeb\Bin\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\NuGet.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Quartz">
       <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
     </Reference>
@@ -88,7 +92,9 @@
     <Compile Include="Model\CareWorkerService.cs" />
     <Compile Include="Model\NoteTemplate.cs" />
     <Compile Include="Model\NoteTemplateService.cs" />
+    <Compile Include="Model\WorkerResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities.cs" />
     <Compile Include="SystemGuid\PersonAttribute.cs" />
     <Compile Include="SystemGuid\SystemCommunication.cs" />
     <Compile Include="SystemGuid\DefinedValue.cs" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -69,7 +69,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Jobs\CareNeedAutomatedNotifications.cs" />
+    <Compile Include="Jobs\CareNeedAutomatedProcesses.cs" />
+    <Compile Include="Migrations\015_UpdateJob.cs" />
     <Compile Include="Migrations\014_NewPageAndAttributes.cs" />
     <Compile Include="Migrations\013_NewPermissions.cs" />
     <Compile Include="Migrations\012_NewBlockSettings.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added new utility methods  to make assignments on scheduled future needs. Updated the Care Need automated notifications job to include Future Need assignment.

**New Settings:**

![image](https://user-images.githubusercontent.com/2990519/181628318-05017818-07b9-40b3-b879-527b4bbd750f.png)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added new capability to system job to assign Care Needs that were scheduled for the future.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

See above.

---------

### Change Log

##### What files does it affect?

- rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedNotifications.cs
- rocks.kfs.StepsToCare/Model/WorkerResult.cs
- rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
- rocks.kfs.StepsToCare/Utilities.cs
- rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, the new utility methods are required for block changes in [RockBlocks#114](https://github.com/KingdomFirst/RockBlocks/pull/114)
