### PR TITLE
Custom Group Reminder Emails

### DIFF
--- a/rocks.kfs.Avalanche/rocks.kfs.Avalanche.csproj
+++ b/rocks.kfs.Avalanche/rocks.kfs.Avalanche.csproj
@@ -62,6 +62,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Avalanche\Plugin\Avalanche.csproj">
+      <Project>{de6b9975-365c-4d0c-8cf9-8b7f5fdcd0d7}</Project>
+      <Name>Avalanche</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/rocks.kfs.Avalanche/rocks.kfs.Avalanche.csproj
+++ b/rocks.kfs.Avalanche/rocks.kfs.Avalanche.csproj
@@ -62,12 +62,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Avalanche\Plugin\Avalanche.csproj">
-      <Project>{de6b9975-365c-4d0c-8cf9-8b7f5fdcd0d7}</Project>
-      <Name>Avalanche</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/rocks.kfs.CustomGroupCommunication/Guids/SystemCommunication.cs
+++ b/rocks.kfs.CustomGroupCommunication/Guids/SystemCommunication.cs
@@ -1,0 +1,26 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+namespace rocks.kfs.CustomGroupCommunication.Guid
+{
+    public static class SystemComunication
+    {
+        /// <summary>
+        /// Zoom Meeting Notification System Communication
+        /// </summary>
+        public const string CUSTOM_GROUP_MEETING_REMINDER = "F2B18235-1BA3-421D-A62B-1713B38B7112";
+    }
+}

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -45,6 +45,14 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
         Order = 1,
         Key = AttributeKey.SystemCommunication )]
 
+    [TextField(
+        "Days Prior",
+        Description = "Comma delimited list of days prior to a scheduled meeting to send a reminder. For example, a value of '2,4' would result in reminders getting sent two and four days prior to the meeting's scheduled meeting date.",
+        DefaultValue = "1",
+        IsRequired = true,
+        Order = 2,
+        Key = AttributeKey.DaysPrior )]
+
     [CustomDropdownListField(
         "Send Using",
         Description = "Specifies how the reminder will be sent.",
@@ -74,6 +82,7 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
         private static class AttributeKey
         {
             public const string SystemCommunication = "SystemCommunication";
+            public const string DaysPrior = "DaysPrior";
             public const string GroupAttributeSetting = "GroupAttributeSetting";
             public const string SendUsing = "SendUsing";
         }

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -40,7 +40,7 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
     [SystemCommunicationField(
         "System Communication",
         Description = "The system communication to use when sending meeting reminders.",
-        DefaultValue = Rock.SystemGuid.SystemCommunication.SCHEDULING_REMINDER,
+        DefaultValue = Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER,
         IsRequired = true,
         Order = 1,
         Key = AttributeKey.SystemCommunication )]

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -45,14 +45,6 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
         Order = 1,
         Key = AttributeKey.SystemCommunication )]
 
-    [TextField(
-        "Days Prior",
-        Description = "Comma delimited list of days prior to a scheduled meeting to send a reminder. For example, a value of '2,4' would result in reminders getting sent two and four days prior to the meeting's scheduled meeting date.",
-        DefaultValue = "1",
-        IsRequired = true,
-        Order = 2,
-        Key = AttributeKey.DaysPrior )]
-
     [CustomDropdownListField(
         "Send Using",
         Description = "Specifies how the reminder will be sent.",
@@ -82,7 +74,6 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
         private static class AttributeKey
         {
             public const string SystemCommunication = "SystemCommunication";
-            public const string DaysPrior = "DaysPrior";
             public const string GroupAttributeSetting = "GroupAttributeSetting";
             public const string SendUsing = "SendUsing";
         }

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -229,6 +229,8 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
                     var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, groupMember.Person );
                     mergeFields.Add( "Group", group );
                     mergeFields.Add( "Person", groupMember.Person );
+                    mergeFields.Add( "NextMeetingDate", group.Schedule.GetNextStartDateTime( DateTime.Now ) );
+
 
                     var notificationType = ( CommunicationType ) Communication.DetermineMediumEntityTypeId(
                                         ( int ) CommunicationType.Email,

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -313,7 +313,7 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
                     var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, groupMember.Person );
                     mergeFields.Add( "Group", group );
                     mergeFields.Add( "Person", groupMember.Person );
-                    mergeFields.Add( "NextMeetingDates", string.Join( "    ", meetingDates ) );
+                    mergeFields.Add( "NextMeetingDates", string.Join( "<br />", meetingDates ) );
 
 
                     var notificationType = ( CommunicationType ) Communication.DetermineMediumEntityTypeId(

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -1,0 +1,382 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Quartz;
+using Rock;
+using Rock.Attribute;
+using Rock.Communication;
+using Rock.Data;
+using Rock.Logging;
+using Rock.Model;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace rocks.kfs.CustomGroupCommunication.Jobs
+{
+    /// <summary>
+    /// Job to process communications
+    /// </summary>
+    [DisplayName( "Send Custom Meeting Reminders" )]
+    [Description( "Sends a reminder to members of a group with the appropriate attribute set for this custom reminder." )]
+
+    #region Job Attributes
+    [SystemCommunicationField(
+        "System Communication",
+        Description = "The system communication to use when sending meeting reminders.",
+        DefaultValue = Rock.SystemGuid.SystemCommunication.SCHEDULING_REMINDER,
+        IsRequired = true,
+        Order = 1,
+        Key = AttributeKey.SystemCommunication )]
+
+    [TextField(
+        "Days Prior",
+        Description = "Comma delimited list of days prior to a scheduled meeting to send a reminder. For example, a value of '2,4' would result in reminders getting sent two and four days prior to the meeting's scheduled meeting date.",
+        DefaultValue = "1",
+        IsRequired = true,
+        Order = 2,
+        Key = AttributeKey.DaysPrior )]
+
+    [CustomDropdownListField(
+        "Send Using",
+        Description = "Specifies how the reminder will be sent.",
+        ListSource = "1^Email,2^SMS,0^Recipient Preference",
+        IsRequired = true,
+        DefaultValue = "1",
+        Order = 3,
+        Key = AttributeKey.SendUsing )]
+
+    [AttributeField(
+        "Group Attribute",
+        Description = "The Group Attribute where we will look for the set value",
+        EntityTypeGuid = Rock.SystemGuid.EntityType.GROUP,
+        IsRequired = true,
+        Order = 4,
+        Key = AttributeKey.GroupAttributeSetting
+        )]
+
+    #endregion Job Attributes
+
+    [DisallowConcurrentExecution]
+    public class CustomMeetingGroupReminder : IJob
+    {
+        /// <summary>
+        /// Attribute Keys
+        /// </summary>
+        private static class AttributeKey
+        {
+            public const string SystemCommunication = "SystemCommunication";
+            public const string DaysPrior = "DaysPrior";
+            public const string GroupAttributeSetting = "GroupAttributeSetting";
+            public const string SendUsing = "SendUsing";
+        }
+
+        private int errorCount = 0;
+        private int notificationEmails = 0;
+        private int notificationSms = 0;
+        private int notificationPush = 0;
+
+        private List<string> errorMessages = new List<string>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom Meeting Group Reminder"/> class.
+        /// </summary>
+        public CustomMeetingGroupReminder()
+        {
+        }
+
+        /// <summary>
+        /// Executes the specified context.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public virtual void Execute( IJobExecutionContext context )
+        {
+            var rockContext = new RockContext();
+            var dataMap = context.JobDetail.JobDataMap;
+
+            var groupAttributeSetting = dataMap.GetString( AttributeKey.GroupAttributeSetting ).AsGuid();
+
+
+            var groups = new GroupService( rockContext ).Queryable().WhereAttributeValue( rockContext, av => av.Attribute.Guid.Equals( groupAttributeSetting ) );
+
+            context.Result = "0 meeting reminders sent.";
+
+            if ( groups == null )
+            {
+                var errorMessages = new List<string>
+                {
+                    $"The Custom Communication Group Attribute job setting is invalid. Please check your Custom Communication job configuration."
+                };
+                HandleErrorMessages( context, errorMessages );
+            }
+
+            var systemCommunicationGuid = dataMap.GetString( AttributeKey.SystemCommunication ).AsGuid();
+            var systemCommunication = new SystemCommunicationService( rockContext ).Get( systemCommunicationGuid );
+
+            var jobPreferredCommunicationType = ( CommunicationType ) dataMap.GetString( AttributeKey.SendUsing ).AsInteger();
+            var isSmsEnabled = MediumContainer.HasActiveSmsTransport() && !string.IsNullOrWhiteSpace( systemCommunication.SMSMessage );
+            var isPushEnabled = MediumContainer.HasActivePushTransport() && !string.IsNullOrWhiteSpace( systemCommunication.PushData );
+
+            if ( jobPreferredCommunicationType == CommunicationType.SMS && !isSmsEnabled )
+            {
+                // If sms selected but not usable default to email.
+                var errorMessages = new List<string>
+                {
+                    $"The job is setup to send via SMS but either SMS isn't enabled or no SMS message was found in system communication {systemCommunication.Title}."
+                };
+                HandleErrorMessages( context, errorMessages );
+            }
+
+            if ( jobPreferredCommunicationType == CommunicationType.PushNotification && !isPushEnabled )
+            {
+                // If push notification selected but not usable default to email.
+                var errorMessages = new List<string>
+                {
+                    $"The job is setup to send via Push Notification but either Push Notifications are not enabled or no Push message was found in system communication {systemCommunication.Title}."
+                };
+                HandleErrorMessages( context, errorMessages );
+            }
+
+            var results = new StringBuilder();
+            if ( jobPreferredCommunicationType == CommunicationType.SMS && string.IsNullOrWhiteSpace( systemCommunication.SMSMessage ) )
+            {
+                var warning = $"No SMS message found in system communication {systemCommunication.Title}. All meeting reminders will be attempted via email.";
+                results.AppendLine( warning );
+                RockLogger.Log.Warning( RockLogDomains.Jobs, warning );
+                jobPreferredCommunicationType = CommunicationType.Email;
+            }
+
+            if ( jobPreferredCommunicationType == CommunicationType.PushNotification && string.IsNullOrWhiteSpace( systemCommunication.PushMessage ) )
+            {
+                var warning = $"No Push message found in system communication {systemCommunication.Title}. All meeting reminders will be attempted via email.";
+                results.AppendLine( warning );
+                RockLogger.Log.Warning( RockLogDomains.Jobs, warning );
+                jobPreferredCommunicationType = CommunicationType.Email;
+            }
+
+            // Process reminders
+            var meetingRemindersResults = SendMeetingReminders( context, rockContext, groups, systemCommunication, jobPreferredCommunicationType, isSmsEnabled, isPushEnabled );
+
+            results.AppendLine( $"{notificationEmails + notificationSms + notificationPush } meeting reminders sent." );
+
+            results.AppendLine( string.Format( "- {0} email(s)\n- {1} SMS message(s)\n- {2} push notification(s)", notificationEmails, notificationSms, notificationPush ) );
+
+            //results.Append( FormatWarningMessages( meetingRemindersResults.Warnings ) );
+
+            context.Result = results.ToString();
+            //HandleErrorMessages( context, meetingRemindersResults.Errors );
+        }
+
+        /// <summary>
+        /// Sends the meeting reminders.
+        /// </summary>
+        /// <param name="context">The overall job context.</param>
+        /// <param name="rockContext">The rockContext.</param>
+        /// <param name="occurrenceData">The occurrenceData to process.</param>
+        /// <param name="systemCommunication">The system communication.</param>
+        /// <param name="jobPreferredCommunicationType">Type of the job preferred communication.</param>
+        /// <returns></returns>
+        private SendMessageResult SendMeetingReminders( IJobExecutionContext context,
+                        RockContext rockContext,
+                        IQueryable<Group> groups,
+                        SystemCommunication systemCommunication,
+                        CommunicationType jobPreferredCommunicationType,
+                        bool isSmsEnabled,
+                        bool isPushEnabled )
+        {
+            var result = new SendMessageResult();
+            var errorsEmail = new List<string>();
+            var errorsSms = new List<string>();
+            var errorsPush = new List<string>();
+
+            // Loop through the room occurrence data
+            foreach ( var group in groups )
+            {
+                var emailMessage = new RockEmailMessage( systemCommunication );
+                RockSMSMessage smsMessage = isSmsEnabled ? new RockSMSMessage( systemCommunication ) : null;
+                RockPushMessage pushMessage = isPushEnabled ? new RockPushMessage( systemCommunication ) : null;
+
+                foreach ( var groupMember in group.ActiveMembers().ToList() )
+                {
+                    groupMember.Person.LoadAttributes();
+                    var smsNumber = groupMember.Person.PhoneNumbers.GetFirstSmsNumber();
+                    var personAlias = new PersonAliasService( rockContext ).Get( groupMember.Person.PrimaryAliasId.Value );
+                    List<string> pushDevices = new PersonalDeviceService( rockContext ).Queryable()
+                        .Where( a => a.PersonAliasId.HasValue && a.PersonAliasId == personAlias.Id && a.NotificationsEnabled )
+                        .Select( a => a.DeviceRegistrationId )
+                        .ToList();
+                    if ( !groupMember.Person.CanReceiveEmail( false ) && smsNumber.IsNullOrWhiteSpace() && pushDevices.Count == 0 )
+                    {
+                        continue;
+                    }
+                    var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, groupMember.Person );
+                    mergeFields.Add( "Group", group );
+                    mergeFields.Add( "Person", groupMember.Person );
+
+                    var notificationType = ( CommunicationType ) Communication.DetermineMediumEntityTypeId(
+                                        ( int ) CommunicationType.Email,
+                                        ( int ) CommunicationType.SMS,
+                                        ( int ) CommunicationType.PushNotification,
+                                        jobPreferredCommunicationType,
+                                        groupMember.CommunicationPreference,
+                                        groupMember.Person.CommunicationPreference );
+
+                    switch ( notificationType )
+                    {
+                        case CommunicationType.Email:
+                            if ( !groupMember.Person.CanReceiveEmail( false ) )
+                            {
+                                errorCount += 1;
+                                errorMessages.Add( string.Format( "{0} does not have a valid email address.", groupMember.Person.FullName ) );
+                            }
+                            else
+                            {
+                                emailMessage.AddRecipient( new RockEmailMessageRecipient( groupMember.Person, mergeFields ) );
+                            }
+                            break;
+                        case CommunicationType.SMS:
+                            if ( string.IsNullOrWhiteSpace( smsNumber ) || smsMessage == null )
+                            {
+                                errorCount += 1;
+                                errorMessages.Add( string.Format( "No SMS number could be found for {0}.", groupMember.Person.FullName ) );
+                                goto case CommunicationType.Email;
+                            }
+                            else
+                            {
+                                smsMessage.AddRecipient( new RockSMSMessageRecipient( groupMember.Person, smsNumber, mergeFields ) );
+                            }
+                            break;
+                        case CommunicationType.PushNotification:
+                            if ( pushDevices.Count == 0 || pushMessage == null )
+                            {
+                                errorCount += 1;
+                                errorMessages.Add( string.Format( "No devices that support notifications could be found for {0}.", groupMember.Person.FullName ) );
+                                goto case CommunicationType.Email;
+                            }
+                            else
+                            {
+                                string deviceIds = String.Join( ",", pushDevices );
+                                pushMessage.AddRecipient( new RockPushMessageRecipient( groupMember.Person, deviceIds, mergeFields ) );
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                if ( emailMessage.GetRecipients().Count > 0 )
+                {
+                    emailMessage.Send( out errorsEmail );
+                    if ( errorsEmail.Any() )
+                    {
+                        result.Errors.AddRange( errorsEmail );
+                    }
+                    else
+                    {
+                        notificationEmails++;
+                    }
+                }
+                if ( smsMessage != null && smsMessage.GetRecipients().Count > 0 )
+                {
+                    smsMessage.Send( out errorsSms );
+                    if ( errorsSms.Any() )
+                    {
+                        result.Errors.AddRange( errorsSms );
+                    }
+                    else
+                    {
+                        notificationSms++;
+                    }
+                }
+                if ( pushMessage != null && pushMessage.GetRecipients().Count > 0 )
+                {
+                    pushMessage.Send( out errorsPush );
+                    if ( errorsPush.Any() )
+                    {
+                        result.Errors.AddRange( errorsPush );
+                    }
+                    else
+                    {
+                        notificationPush++;
+                    }
+                }
+            }
+            if ( errorMessages.Any() )
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine();
+                sb.Append( string.Format( "{0} Errors: ", errorCount ) );
+                errorMessages.ForEach( e => { sb.AppendLine(); sb.Append( e ); } );
+                string errors = sb.ToString();
+                context.Result += errors;
+                var exception = new Exception( errors );
+                HttpContext context2 = HttpContext.Current;
+                ExceptionLogService.LogException( exception, context2 );
+                throw exception;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Handles the error messages.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        private void HandleErrorMessages( IJobExecutionContext context, List<string> errorMessages )
+        {
+            if ( errorMessages.Any() )
+            {
+                StringBuilder sb = new StringBuilder( context.Result.ToString() );
+
+                sb.Append( FormatMessages( errorMessages, "Error" ) );
+
+                var resultMessage = sb.ToString();
+
+                context.Result = resultMessage;
+
+                var exception = new Exception( resultMessage );
+
+                HttpContext context2 = HttpContext.Current;
+                ExceptionLogService.LogException( exception, context2 );
+                throw exception;
+            }
+        }
+
+        /// <summary>
+        /// Formats the messages.
+        /// </summary>
+        /// <param name="messages">The messages.</param>
+        /// <param name="label">The label.</param>
+        /// <returns></returns>
+        private StringBuilder FormatMessages( List<string> messages, string label )
+        {
+            StringBuilder sb = new StringBuilder();
+            if ( messages.Any() )
+            {
+                var pluralizedLabel = label.PluralizeIf( messages.Count > 1 );
+
+                sb.AppendLine( $"{messages.Count} {pluralizedLabel}:" );
+
+                messages.ForEach( w => { sb.AppendLine( w ); } );
+            }
+            return sb;
+        }
+    }
+}

--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -186,9 +186,11 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
         /// </summary>
         /// <param name="context">The overall job context.</param>
         /// <param name="rockContext">The rockContext.</param>
-        /// <param name="occurrenceData">The occurrenceData to process.</param>
+        /// <param name="groups">The groups.</param>
         /// <param name="systemCommunication">The system communication.</param>
         /// <param name="jobPreferredCommunicationType">Type of the job preferred communication.</param>
+        /// <param name="isSmsEnabled">if set to <c>true</c> [is SMS enabled].</param>
+        /// <param name="isPushEnabled">if set to <c>true</c> [is push enabled].</param>
         /// <returns></returns>
         private SendMessageResult SendMeetingReminders( IJobExecutionContext context,
                         RockContext rockContext,

--- a/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
+++ b/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
@@ -27,17 +27,17 @@ namespace rocks.kfs.CustomGroupCommunication.Migrations
         {
             RockMigrationHelper.UpdateSystemCommunication( "Plugins"
                 , "Group Meeting Reminder", "", "", "", "", ""
-                , "You have a group meeting starting soon", @"{{ 'Global' | Attribute:'EmailHeader' }}
+                , "You have group meeting(s) starting soon", @"{{ 'Global' | Attribute:'EmailHeader' }}
                     <p>{{ Person.FullName }},</p>
                     <p>You have a scheduled group meeting coming up:</p>
                     <blockquote><b>Meeting for {{ Group.Name }}</b><br>
-                    <b>Date:</b> {{ NextMeetingDates }}</blockquote>
+                    <b>Date(s):</b> {{ NextMeetingDates }}</blockquote>
                     {{ 'Global' | Attribute:'EmailFooter' }}"
                 , Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER
                 , isActive: true
-                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDates }} )."
+                , smsMessage: @"Upcoming group meeting(s) for {{ Group.Name }} ( {{ NextMeetingDates }} )."
                 , pushTitle: "Upcoming Group Meeting"
-                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDates }} )." );
+                , pushMessage: @"Upcoming group meeting(s) for {{ Group.Name }} ( {{ NextMeetingDates }} )." );
 
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER ) );
         }

--- a/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
+++ b/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
@@ -1,0 +1,52 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock;
+using Rock.Model;
+using Rock.Plugin;
+
+namespace rocks.kfs.CustomGroupCommunication.Migrations
+{
+    [MigrationNumber( 1, "1.12.4" )]
+    public partial class CreateCommunications : Migration
+    {
+        public override void Up()
+        {
+            RockMigrationHelper.UpdateSystemCommunication( "Plugins"
+                , "Group Meeting Reminder", "", "", "", "", ""
+                , "You have a group meeting starting soon", @"{{ 'Global' | Attribute:'EmailHeader' }}
+                    <p>{{ Person.FullName }},</p>
+                    <p>You have a scheduled group meeting coming up:</p>
+                    <blockquote><b>Meeting for {{ Group.Name }}</b><br>
+                    <b>Date:</b> {{ Occurrence.StartTime }}<br>
+                    <b>Topic:</b> {{ Occurrence.Topic }}</blockquote>
+                    {{ 'Global' | Attribute:'EmailFooter' }}"
+                , Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER
+                , isActive: true
+                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ Occurrence.StartTime }} )."
+                , pushTitle: "Upcoming Group Meeting"
+                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ Occurrence.StartTime }} )." );
+        }
+
+        /// <summary>
+        /// Operations to be performed during the downgrade process.
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteSystemCommunication( Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER );
+        }
+    }
+}

--- a/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
+++ b/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
@@ -31,7 +31,7 @@ namespace rocks.kfs.CustomGroupCommunication.Migrations
                     <p>{{ Person.FullName }},</p>
                     <p>You have a scheduled group meeting coming up:</p>
                     <blockquote><b>Meeting for {{ Group.Name }}</b><br>
-                    <b>Date:</b> {{ NextMeetingDate }}</blockquote>
+                    <b>Date:</b> {{ NextMeetingDates }}</blockquote>
                     {{ 'Global' | Attribute:'EmailFooter' }}"
                 , Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER
                 , isActive: true

--- a/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
+++ b/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
@@ -31,14 +31,15 @@ namespace rocks.kfs.CustomGroupCommunication.Migrations
                     <p>{{ Person.FullName }},</p>
                     <p>You have a scheduled group meeting coming up:</p>
                     <blockquote><b>Meeting for {{ Group.Name }}</b><br>
-                    <b>Date:</b> {{ Occurrence.StartTime }}<br>
-                    <b>Topic:</b> {{ Occurrence.Topic }}</blockquote>
+                    <b>Date:</b> {{ NextMeetingDate }}</blockquote>
                     {{ 'Global' | Attribute:'EmailFooter' }}"
                 , Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER
                 , isActive: true
-                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ Occurrence.StartTime }} )."
+                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDate }} )."
                 , pushTitle: "Upcoming Group Meeting"
-                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ Occurrence.StartTime }} )." );
+                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDate }} )." );
+
+            Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER ) );
         }
 
         /// <summary>

--- a/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
+++ b/rocks.kfs.CustomGroupCommunication/Migrations/001_CreateCommunications.cs
@@ -35,9 +35,9 @@ namespace rocks.kfs.CustomGroupCommunication.Migrations
                     {{ 'Global' | Attribute:'EmailFooter' }}"
                 , Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER
                 , isActive: true
-                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDate }} )."
+                , smsMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDates }} )."
                 , pushTitle: "Upcoming Group Meeting"
-                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDate }} )." );
+                , pushMessage: @"Upcoming group meeting for {{ Group.Name }} ( {{ NextMeetingDates }} )." );
 
             Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", Guid.SystemComunication.CUSTOM_GROUP_MEETING_REMINDER ) );
         }

--- a/rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "rocks.kfs.CustomGroupCommunication" )]
+[assembly: AssemblyProduct( "rocks.kfs.CustomGroupCommunication" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+
+// Auto increment assembly versions
+[assembly: AssemblyVersion( "1.0.*" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2" )]

--- a/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
+++ b/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
@@ -65,7 +65,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Guids\SystemCommunication.cs" />
     <Compile Include="Jobs\MeetingGroupReminder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
+++ b/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
@@ -46,6 +46,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\EntityFramework.Utilities.dll</HintPath>
     </Reference>
+    <Reference Include="Ical.Net, Version=2.1.0.20781, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="Quartz">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>

--- a/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
+++ b/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
@@ -65,7 +65,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Guids\SystemCommunication.cs" />
     <Compile Include="Jobs\MeetingGroupReminder.cs" />
+    <Compile Include="Migrations\001_CreateCommunications.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
+++ b/rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>rocks.kfs.CustomGroupCommunication</RootNamespace>
+    <AssemblyName>rocks.kfs.CustomGroupCommunication</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotLiquid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\DotLiquid.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.Utilities">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\EntityFramework.Utilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Quartz">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Guids\SystemCommunication.cs" />
+    <Compile Include="Jobs\MeetingGroupReminder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R "$(TargetPath)" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(TargetDir)$(TargetName).pdb" "$(SolutionDir)RockWeb\bin"</PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Description 

Adds a job that allows for custom reminder emails to be sent on a group by group basis

**New Settings:**

* System Communication - System communication to be used for the reminder
* Send Using - Communication Transport to be used for the reminder
* Group Attribute - The attribute on the group that must be set to true to trigger the reminder
---------

### Release Notes 

New Job that will send reminders to a group based on the Job schedule as long as they are marked with a configured group attribute of type boolean that is set to true.

---------

### Requested By

CBC - Neenah

---------

### Screenshots

![image](https://user-images.githubusercontent.com/2577926/185201600-edfb490e-d1db-4799-9d29-d814b0b3ad25.png)


![image](https://user-images.githubusercontent.com/2577926/185494983-e16fe75e-eec3-4714-b821-b4e5046dff38.png)


---------

### Change Log

* rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs - Job
* rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs - Project definition
* rocks.kfs.CustomGroupCommunication/rocks.kfs.CustomGroupCommunication.csproj - Project Definition

---------

### Migrations/External Impacts

No
