### PR TITLE
Eventbrite Null Checks and Duplicate Prevention

### DIFF
--- a/EventBriteDotNetFramework/Entities/Event.cs
+++ b/EventBriteDotNetFramework/Entities/Event.cs
@@ -58,10 +58,13 @@ namespace EventbriteDotNetFramework.Entities
         {
             var retVar = false;
             var cq = eb.GetEventCannedQuestionsById( Id );
-            var test = cq.Questions.FirstOrDefault( q => q.Respondent.Equals( "attendee", StringComparison.CurrentCultureIgnoreCase ) );
-            if ( test == null )
+            if ( cq != null && cq.Questions != null )
             {
-                retVar = true;
+                var test = cq.Questions.FirstOrDefault( q => q.Respondent.Equals( "attendee", StringComparison.CurrentCultureIgnoreCase ) );
+                if ( test == null )
+                {
+                    retVar = true;
+                }
             }
             return retVar;
         }
@@ -71,10 +74,13 @@ namespace EventbriteDotNetFramework.Entities
             var retVar = false;
             var eb = new EBApi( oAuthToken );
             var cq = eb.GetEventCannedQuestionsById( Id );
-            var test = cq.Questions.FirstOrDefault( q => q.Respondent.Equals( "attendee", StringComparison.CurrentCultureIgnoreCase ) );
-            if ( test == null )
+            if ( cq != null && cq.Questions != null )
             {
-                retVar = true;
+                var test = cq.Questions.FirstOrDefault( q => q.Respondent.Equals( "attendee", StringComparison.CurrentCultureIgnoreCase ) );
+                if ( test == null )
+                {
+                    retVar = true;
+                }
             }
             return retVar;
         }

--- a/EventBriteDotNetFramework/Properties/AssemblyInfo.cs
+++ b/EventBriteDotNetFramework/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.2.*" )]
+[assembly: AssemblyVersion( "1.3.*" )]

--- a/EventBriteDotNetFramework/Properties/AssemblyInfo.cs
+++ b/EventBriteDotNetFramework/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]

--- a/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
+++ b/rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs
@@ -58,10 +58,13 @@ namespace rocks.kfs.Eventbrite.Field.Types
                 var linkedEventTickets = eb.GetTicketsById( longVal.Value );
                 var sold = 0;
                 var total = 0;
-                foreach ( var ticket in linkedEventTickets.Ticket_Classes )
+                if ( linkedEventTickets != null && linkedEventTickets.Ticket_Classes != null )
                 {
-                    sold += ticket.QuantitySold;
-                    total += ticket.QuantityTotal;
+                    foreach ( var ticket in linkedEventTickets.Ticket_Classes )
+                    {
+                        sold += ticket.QuantitySold;
+                        total += ticket.QuantityTotal;
+                    }
                 }
                 var available = total - sold;
 
@@ -69,13 +72,27 @@ namespace rocks.kfs.Eventbrite.Field.Types
                 {
                     if ( condensed )
                     {
-                        formattedValue = string.Format( "{0} - {1} ({2})", eventbriteEvent.Name.Text, eventbriteEvent.Start.Local, eventbriteEvent.Status );
+                        if ( eventbriteEvent.Name != null )
+                        {
+                            formattedValue = string.Format( "{0} - {1} ({2})", eventbriteEvent.Name.Text, eventbriteEvent.Start.Local, eventbriteEvent.Status );
+                        }
+                        else
+                        {
+                            formattedValue = "Unable to retrieve Event name from Eventbrite, are you authenticated?";
+                        }
                     }
                     else
                     {
                         var eventbriteStatus = new StringBuilder();
                         eventbriteStatus.Append( "<dl>" );
-                        eventbriteStatus.AppendFormat( "<dd>{0} - {1} ({2})</dd>", eventbriteEvent.Name.Html, eventbriteEvent.Start.Local, eventbriteEvent.Status );
+                        if ( eventbriteEvent.Name != null )
+                        {
+                            eventbriteStatus.AppendFormat( "<dd>{0} - {1} ({2})</dd>", eventbriteEvent.Name.Html, eventbriteEvent.Start.Local, eventbriteEvent.Status );
+                        }
+                        else
+                        {
+                            eventbriteStatus.Append( "<dd>Unable to retrieve Event from Eventbrite, are you authenticated?</dd>" );
+                        }
                         eventbriteStatus.AppendFormat( "<dt>Link</dt><dd><a href={0}>{0}</a></dd>", eventbriteEvent.Url );
                         eventbriteStatus.AppendFormat( "<dt>Capacity</dt><dd>{0}</dd>", eventbriteEvent.Capacity.ToString() );
                         eventbriteStatus.AppendFormat( "<dt>Tickets</dt><dd>{0} Available + {1} Sold = {2} Total</dd>", available, sold, total );
@@ -108,7 +125,7 @@ namespace rocks.kfs.Eventbrite.Field.Types
             var eb = new EBApi( Settings.GetAccessToken(), Settings.GetOrganizationId().ToLong( 0 ) );
 
             var organizationEvents = eb.GetOrganizationEvents( "all", 500 );
-            if ( organizationEvents.Pagination.Has_More_Items )
+            if ( organizationEvents != null && organizationEvents.Pagination != null && organizationEvents.Pagination.Has_More_Items )
             {
                 var looper = new OrganizationEventsResponse();
                 for ( int i = 2; i <= organizationEvents.Pagination.PageCount; i++ )

--- a/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.EventBrite/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.4.*" )]
+[assembly: AssemblyVersion( "1.5.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added protection for saving an invalid token in Eventbrite settings.
- Added additional null checks to prevent exceptions.
- Added additional logic to attempt to match on event/order id/name first prior to adding/matching a new person. This helps address the new Elevated Security level duplicates that can be created. (Fixes #85)
- Fixed the sorting of the orders to help process multiple orders by the same person and/or process refunds/deletes prior to new orders from the same person.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added protection for saving an invalid token in Eventbrite settings.
- Added additional null checks to prevent exceptions.
- Added additional logic to attempt to match on event/order id/name first prior to adding/matching a new person.
- Addressed an issue with processing orders from the same first name, last name and email. Including if the person cancels or refunds their order then orders again.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Reported by CCBC, Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No, all internal.

---------

### Change Log

##### What files does it affect?

- EventBriteDotNetFramework/Entities/Event.cs
- EventBriteDotNetFramework/Properties/AssemblyInfo.cs
- rocks.kfs.EventBrite/Eventbrite.cs
- rocks.kfs.EventBrite/Field/Types/EventbriteEventFieldType.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
