### PR TITLE
Zoom Reminders Editable

### DIFF
--- a/rocks.kfs.Zoom/Migrations/008_MakeCommunicationsEditable.cs
+++ b/rocks.kfs.Zoom/Migrations/008_MakeCommunicationsEditable.cs
@@ -1,0 +1,39 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock;
+using Rock.Model;
+using Rock.Plugin;
+
+namespace rocks.kfs.Zoom.Migrations
+{
+    [MigrationNumber( 8, "1.12.4" )]
+    public partial class MakeCommunicationsEditable : Migration
+    {
+        public override void Up()
+        {
+            Sql( string.Format( "UPDATE [SystemCommunication] SET [IsSystem] = 0 WHERE [Guid] = '{0}'", ZoomGuid.SystemComunication.ZOOM_MEETING_REMINDER ) );
+        }
+
+        /// <summary>
+        /// Operations to be performed during the downgrade process.
+        /// </summary>
+        public override void Down()
+        {
+            
+        }
+    }
+}

--- a/rocks.kfs.Zoom/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Zoom/Properties/AssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("2e6ca020-205d-4fb8-ad08-91866d653c4b")]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]

--- a/rocks.kfs.Zoom/rocks.kfs.Zoom.csproj
+++ b/rocks.kfs.Zoom/rocks.kfs.Zoom.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Enums\ZoomMeetingRequestStatus.cs" />
     <Compile Include="Jobs\ZoomMeetingGroupReminder.cs" />
     <Compile Include="Jobs\ZoomRoomSchedulingAndMaintenance.cs" />
+    <Compile Include="Migrations\008_MakeCommunicationsEditable.cs" />
     <Compile Include="Migrations\007_DataViewsAndReports.cs" />
     <Compile Include="Migrations\006_PageAndBlocks.cs" />
     <Compile Include="Migrations\003_CreateAttributeQualifiers.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixes ability to edit zoom system communications

---------

### Release Notes 

* Fixed bug that prevented users from editing the zoom meeting reminder communication

---------

### Requested By

KFS

---------

### Screenshots

N/A

---------

### Change Log

* rocks.kfs.Zoom/Migrations/008_MakeCommunicationsEditable.cs - new migration
* rocks.kfs.Zoom/Properties/AssemblyInfo.cs - update version
* rocks.kfs.Zoom/rocks.kfs.Zoom.csproj - added migration to the project

---------

### Migrations/External Impacts

None
