### PR TITLE
SMS Conversation Workflow Action

### DIFF
--- a/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
+++ b/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
@@ -110,11 +110,6 @@ namespace rocks.kfs.Workflow.Action.Communication
                 return true;
             }
 
-            // mark as approved if needed
-            if ( isRead )
-            {
-                dateRead = RockDateTime.Now;
-            }
             var smsMediumEntityTypeId = EntityTypeCache.GetId( Rock.SystemGuid.EntityType.COMMUNICATION_MEDIUM_SMS ).Value;
             var smsDefinedValueId = DefinedValueCache.GetId( smsFromGuid ?? Guid.Empty );
             var smsTransport = new Rock.Communication.Medium.Sms().Transport.EntityType.Id;

--- a/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
+++ b/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
@@ -41,7 +41,7 @@ namespace rocks.kfs.Workflow.Action.Communication
     #region Action Settings
 
     [TextField( "Message in Conversation", "Message to display in conversation as though it was from the recipient. Default: Blank <span class='tip tip-lava'></span>", false, "" )]
-    [BooleanField( "Mark as Read", "Flag indicating if the conversation should be marked as read when submitted. Default: false", defaultValue: false, order: 1 )]
+    [BooleanField( "Mark as Read", "Flag indicating if the conversation should be marked as read when submitted. Default: No", defaultValue: false, order: 1 )]
     [WorkflowAttribute( "Person", "The workflow attribute of the person to be the recipient.", true, "", "", 7, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
     [DefinedValueField( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM, "SMS From Number", "The SMS number the conversation will appear under.", false, false )]
     #endregion

--- a/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
+++ b/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
@@ -1,0 +1,144 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Workflow;
+
+namespace rocks.kfs.Workflow.Action.Communication
+{
+    #region Action Attributes
+
+    [ActionCategory( "KFS: Communication" )]
+    [Description( "Creates a new SMS Conversation." )]
+    [Export( typeof( ActionComponent ) )]
+    [ExportMetadata( "ComponentName", "Add SMS Conversation" )]
+
+    #endregion
+
+    #region Action Settings
+
+    [TextField( "Message in Conversation", "Message to display in conversation as though it was from the recipient. Default: Blank <span class='tip tip-lava'></span>", false, "" )]
+    [BooleanField( "Mark as Read", "Flag indicating if the conversation should be marked as read when submitted. Default: false", defaultValue: false, order: 1 )]
+    [WorkflowAttribute( "Person", "The workflow attribute of the person to be the recipient.", true, "", "", 7, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    [DefinedValueField( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM, "SMS From Number", "The SMS number the conversation will appear under.", false, false )]
+    #endregion
+
+    /// <summary>
+    /// Creates a new prayer request.
+    /// </summary>
+    public class AddSMSConversation : ActionComponent
+    {
+        /// <summary>
+        /// Executes the action.
+        /// </summary>
+        /// <param name="rockContext">The rock context.</param>
+        /// <param name="action">The workflow action.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Execute(RockContext rockContext, WorkflowAction action, Object entity, out List<string> errorMessages)
+        {
+            errorMessages = new List<string>();
+
+            Person person = null;
+            int? conversationPersonAliasId = null;
+            var isRead = GetAttributeValue( action, "MarkasRead" ).AsBoolean();
+            var message = GetAttributeValue( action, "MessageinConversation" );
+            var smsFromGuid = GetAttributeValue( action, "SMSFromNumber" ).AsGuidOrNull();
+
+            DateTime dateRead;
+
+            // get person
+            Guid? personAttributeGuid = GetAttributeValue( action, "Person" ).AsGuidOrNull();
+            if ( personAttributeGuid.HasValue )
+            {
+                Guid? personAliasGuid = action.GetWorkflowAttributeValue( personAttributeGuid.Value ).AsGuidOrNull();
+                if ( personAliasGuid.HasValue )
+                {
+                    var personAlias = new PersonAliasService( rockContext ).Get( personAliasGuid.Value );
+                    if ( personAlias != null )
+                    {
+                        person = personAlias.Person;
+                    }
+                }
+            }
+
+            // get name and campus info
+            if ( person != null )
+            {
+                conversationPersonAliasId = person.PrimaryAliasId;
+            }
+            else
+            {
+                // invalid conversation
+                errorMessages.Add( "A valid person is required to use this action." );
+                return true;
+            }
+
+
+
+            // mark as approved if needed
+            if ( isRead )
+            {
+                dateRead = RockDateTime.Now;
+            }
+            var smsMediumEntityTypeId = EntityTypeCache.GetId( Rock.SystemGuid.EntityType.COMMUNICATION_MEDIUM_SMS ).Value;
+            var smsDefinedValueId = DefinedValueCache.GetId( smsFromGuid ?? Guid.Empty );
+
+            //IQueryable<CommunicationResponse> communicationResponseQuery = this.Queryable()
+            //    .Where( r => r.RelatedMediumEntityTypeId == smsMediumEntityTypeId && r.RelatedSmsFromDefinedValueId == relatedSmsFromDefinedValueId && r.CreatedDateTime >= startDateTime && r.FromPersonAliasId.HasValue );
+
+            // create the conversation
+            var response = new CommunicationResponse
+            {
+                FromPersonAliasId = conversationPersonAliasId,
+                IsRead = isRead,
+                CreatedDateTime = RockDateTime.Now,
+                CreatedByPersonAliasId = conversationPersonAliasId,
+                RelatedSmsFromDefinedValueId = smsDefinedValueId,
+                RelatedMediumEntityTypeId = smsMediumEntityTypeId,
+                Response = message
+            };
+
+            // add the SMS Conversation
+            var communicationResponseService = new CommunicationResponseService( rockContext );
+            communicationResponseService.Add( response );
+
+            // save the Conversation
+            rockContext.WrapTransaction( () =>
+            {
+                rockContext.SaveChanges();
+            } );
+
+            if ( response.Guid != null )
+            {
+
+            }
+
+            return true;
+        }
+    }
+}

--- a/rocks.kfs.Workflow.Action.Communication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Workflow.Action.Communication/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "rocks.kfs.Workflow.Action.Communication" )]
+[assembly: AssemblyProduct( "rocks.kfs.Workflow.Action.Communication" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+
+// Auto increment assembly versions
+[assembly: AssemblyVersion( "1.0.*" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "1832b422-27f0-11ed-a261-0242ac120002" )]

--- a/rocks.kfs.Workflow.Action.Communication/rocks.kfs.Workflow.Action.Communication.csproj
+++ b/rocks.kfs.Workflow.Action.Communication/rocks.kfs.Workflow.Action.Communication.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1832B422-27F0-11ED-A261-0242AC120002}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>rocks.kfs.Workflow.Action.Communication</RootNamespace>
+    <AssemblyName>rocks.kfs.Workflow.Action.Communication</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotLiquid">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\DotLiquid.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AddSMSConversation.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R "$(TargetPath)" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(TargetDir)$(TargetName).pdb" "$(SolutionDir)RockWeb\bin"</PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added new workflow action to drop a person into SMS conversations and/or display a new custom message for visibility within the SMS conversations block.

**New Settings:**

- **Message in Conversation**, Message to display in conversation as though it was from the recipient.
- **SMS From Number**, The SMS number the conversation will appear under.
- **Mark as Read**, Flag indicating if the conversation should be marked as read when submitted.
- **Person**, The workflow attribute of the person to be the recipient.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Added new workflow action to drop a person into SMS conversations and/or display a new custom message for visibility within the SMS conversations block.

---------

### Requested By

##### Who reported, requested, or paid for the change?

CBCN

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/187548330-ece4e32c-f3c8-478e-b7af-a858c233812c.png)

![image](https://user-images.githubusercontent.com/2990519/187548092-6dc729df-848e-4221-96e5-ea58ea6a2d8f.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
- rocks.kfs.Workflow.Action.Communication/Properties/AssemblyInfo.cs
- rocks.kfs.Workflow.Action.Communication/rocks.kfs.Workflow.Action.Communication.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
