### PR TITLE
Round Robin Group Add Job - Family Members

### DIFF
--- a/KFSRock.sln.kfs
+++ b/KFSRock.sln.kfs
@@ -157,6 +157,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Workflow.Action.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.StepsToCare", "KFSRockAssemblies\rocks.kfs.StepsToCare\rocks.kfs.StepsToCare.csproj", "{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Zoom", "KFSRockAssemblies\rocks.kfs.Zoom\rocks.kfs.Zoom.csproj", "{2E6CA020-205D-4FB8-AD08-91866D653C4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZoomDotNetFramework", "KFSRockAssemblies\ZoomDotNetFramework\ZoomDotNetFramework.csproj", "{99DA9675-2596-43B9-A623-0AD3C742FD3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.GroupRoundRobinAssignment", "KFSRockAssemblies\rocks.kfs.GroupRoundRobinAssignment\rocks.kfs.GroupRoundRobinAssignment.csproj", "{E2040E07-572B-4629-8B9F-6B53EC7C077C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.CustomGroupCommunication", "KFSRockAssemblies\rocks.kfs.CustomGroupCommunication\rocks.kfs.CustomGroupCommunication.csproj", "{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -423,6 +431,22 @@ Global
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99DA9675-2596-43B9-A623-0AD3C742FD3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99DA9675-2596-43B9-A623-0AD3C742FD3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99DA9675-2596-43B9-A623-0AD3C742FD3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99DA9675-2596-43B9-A623-0AD3C742FD3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2040E07-572B-4629-8B9F-6B53EC7C077C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2040E07-572B-4629-8B9F-6B53EC7C077C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2040E07-572B-4629-8B9F-6B53EC7C077C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2040E07-572B-4629-8B9F-6B53EC7C077C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
+++ b/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
@@ -34,14 +34,14 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
     /// </summary>
     ///
     [DataViewField(
-        "People to Add Data View",
+        "People Data View",
         Description = "Select the data view you wish to use as your source for people to add to the round robin group assignment. For speed purposes we recommend it filter out people already assigned to groups.",
         IsRequired = true,
         EntityTypeName = "Rock.Model.Person",
         Key = AttributeKey.PeopleToAddDataView )]
 
     [CustomEnhancedListField(
-        "Groups to Cycle Through",
+        "Groups to Assign People to",
         Description = "Select the groups and/or parent groups to cycle assigning users to based on campus group = person group.",
          ListSource = @"SELECT 
         CASE WHEN ggpg.Name IS NOT NULL THEN
@@ -85,9 +85,16 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
 
     [BooleanField(
         "Include Selected Groups",
-        Description = "Should we include the selected groups in the round robin assignment or only the child groups? Default: False",
+        Description = "Should we include the selected groups in the round robin assignment or only the child groups? Default: No",
         DefaultBooleanValue = false,
         Key = AttributeKey.IncludeSelectedGroups )]
+
+    [CustomDropdownListField(
+        "Include Family Members",
+        Description = "Should we include family members in the group as each person gets assigned? 'None', each person in the data view gets assigned to a different group. 'Adults Only', Family members with the 'Adult' Role will be added to the same group. 'All Family Members', every family member for the first individual encountered will be assigned to the same group. Default: All Family Members",
+        DefaultValue = "All",
+        ListSource = "All^All Family Members,Adults^Adults Only,None",
+        Key = AttributeKey.IncludeFamilyMembers )]
 
     [DisallowConcurrentExecution]
     public class GroupRoundRobinAssignment : IJob
@@ -102,6 +109,7 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
             public const string DefaultCampus = "DefaultCampus";
             public const string DefaultGroup = "DefaultGroup";
             public const string IncludeSelectedGroups = "IncludeSelectedGroups";
+            public const string IncludeFamilyMembers = "IncludeFamilyMembers";
         }
 
         private List<string> errorMessages = new List<string>();
@@ -126,6 +134,7 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
             var defaultGroupGuid = dataMap.GetString( AttributeKey.DefaultGroup ).AsGuidOrNull();
             var defaultCampusGuid = dataMap.GetString( AttributeKey.DefaultCampus ).AsGuidOrNull();
             var includeSelectedGroups = dataMap.GetBooleanFromString( AttributeKey.IncludeSelectedGroups );
+            var includeFamilyMembers = dataMap.GetString( AttributeKey.IncludeFamilyMembers );
             var addedCount = 0;
 
             using ( var rockContext = new RockContext() )
@@ -222,29 +231,36 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
                                 addedPeopleIds.Add( person.Id );
                                 addedCount++;
 
-                                foreach ( var familyMember in person.GetFamilyMembers( false, rockContext ) )
+                                if ( includeFamilyMembers != "None" )
                                 {
-                                    var fPerson = familyMember.Person;
-                                    try
+                                    foreach ( var familyMember in person.GetFamilyMembers( false, rockContext ) )
                                     {
-                                        var fGroupMember = new GroupMember
-                                        {
-                                            PersonId = fPerson.Id,
-                                            GroupId = groupToAddTo.Id,
-                                            GroupRoleId = groupToAddTo.GroupType.DefaultGroupRoleId.Value,
-                                            GroupMemberStatus = GroupMemberStatus.Active
-                                        };
+                                        var fPerson = familyMember.Person;
 
-                                        if ( fGroupMember.IsValidGroupMember( rockContext ) )
+                                        if ( includeFamilyMembers != "Adults" || fPerson.GetFamilyRole( rockContext ).Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() )
                                         {
-                                            groupMemberService.Add( fGroupMember );
-                                            addedPeopleIds.Add( fPerson.Id );
-                                            addedCount++;
+                                            try
+                                            {
+                                                var fGroupMember = new GroupMember
+                                                {
+                                                    PersonId = fPerson.Id,
+                                                    GroupId = groupToAddTo.Id,
+                                                    GroupRoleId = groupToAddTo.GroupType.DefaultGroupRoleId.Value,
+                                                    GroupMemberStatus = GroupMemberStatus.Active
+                                                };
+
+                                                if ( fGroupMember.IsValidGroupMember( rockContext ) )
+                                                {
+                                                    groupMemberService.Add( fGroupMember );
+                                                    addedPeopleIds.Add( fPerson.Id );
+                                                    addedCount++;
+                                                }
+                                            }
+                                            catch ( Exception e )
+                                            {
+                                                errorMessages.Add( string.Format( "There was an error adding family member {0} ({1}) to {2} group. Exception: {3}", fPerson.FullName, fPerson.Id, groupToAddTo.Name, e.Message ) );
+                                            }
                                         }
-                                    }
-                                    catch ( Exception e )
-                                    {
-                                        errorMessages.Add( string.Format( "There was an error adding family member {0} ({1}) to {2} group. Exception: {3}", fPerson.FullName, fPerson.Id, groupToAddTo.Name, e.Message ) );
                                     }
                                 }
                             }
@@ -254,6 +270,10 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
                             if ( person.PrimaryCampusId == null )
                             {
                                 errorMessages.Add( string.Format( "{0} ({1}) does not have a campus set and there are no defaults set on the job. Please try again.", person.FullName, person.Id ) );
+                            }
+                            else if ( groupToAddTo != null )
+                            {
+                                errorMessages.Add( string.Format( "{0} ({1}) was added with a family member or is already in a group assignment. You may ignore this error or consider refining your data view to single members of household. ", person.FullName, person.Id ) );
                             }
                             else
                             {

--- a/rocks.kfs.GroupRoundRobinAssignment/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.GroupRoundRobinAssignment/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
+++ b/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{E2040E07-572B-4629-8B9F-6B53EC7C077C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>rocks.kfs.GroupRoleAttendanceReminder</RootNamespace>
-    <AssemblyName>rocks.kfs.GroupRoleAttendanceReminder</AssemblyName>
+    <RootNamespace>rocks.kfs.GroupRoundRobinAssignment</RootNamespace>
+    <AssemblyName>rocks.kfs.GroupRoundRobinAssignment</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
+++ b/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
@@ -49,7 +49,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Jobs\GroupRoundRobinAssignment.cs" />
-    <Compile Include="Migrations\001_AddRoundRobinAssignmentJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
+++ b/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Jobs\GroupRoundRobinAssignment.cs" />
+    <Compile Include="Migrations\001_AddRoundRobinAssignmentJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Adds the capability to include family members into the same group when assigning a person from the data view.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added support to include family members in the round robin group assignment.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/188764332-3bf43ff8-bec6-4c0d-9c34-e8801907c6fd.png)

---------

### Change Log

##### What files does it affect?

- KFSRock.sln.kfs
- rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
- rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
- rocks.kfs.GroupRoundRobinAssignment/Properties/AssemblyInfo.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No