### PR TITLE
Add SMS Conversation Fix and DoorkeeperOAuth Null Check

### DIFF
--- a/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs
+++ b/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs
@@ -492,12 +492,15 @@ namespace com.kfs.Security.ExternalAuthentication
                             person.PhoneNumbers.Add( phoneNumber );
                             phoneNumber.Number = PhoneNumber.CleanNumber( oauthUser.contact.phone.AsNumeric() );
 
-                            var birthday = oauthUser.contact.birthday.Split( ( new char[] { '-' } ) );
-                            if ( birthday.Length == 3 )
+                            if ( oauthUser.contact != null && !string.IsNullOrWhiteSpace( oauthUser.contact.birthday ) )
                             {
-                                person.BirthYear = birthday[0].AsIntegerOrNull();
-                                person.BirthMonth = birthday[1].AsIntegerOrNull();
-                                person.BirthDay = birthday[2].AsIntegerOrNull();
+                                var birthday = oauthUser.contact.birthday.Split( ( new char[] { '-' } ) );
+                                if ( birthday.Length == 3 )
+                                {
+                                    person.BirthYear = birthday[0].AsIntegerOrNull();
+                                    person.BirthMonth = birthday[1].AsIntegerOrNull();
+                                    person.BirthDay = birthday[2].AsIntegerOrNull();
+                                }
                             }
 
                             var gender = oauthUser.contact.gender_id.AsIntegerOrNull();
@@ -511,31 +514,34 @@ namespace com.kfs.Security.ExternalAuthentication
                                 PersonService.SaveNewPerson( person, rockContext, null, false );
                             }
 
-                            // save address
-                            var personLocation = new LocationService( rockContext )
-                                                    .Get( oauthUser.address.street1, oauthUser.address.street2,
-                                                        oauthUser.address.city, oauthUser.address.state, oauthUser.address.zip, oauthUser.address.country );
-                            if ( personLocation != null )
+                            if ( oauthUser.address != null && !string.IsNullOrWhiteSpace( oauthUser.address.street1 ) )
                             {
-                                Guid locationTypeGuid = Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid();
-                                if ( locationTypeGuid != Guid.Empty )
+                                // save address
+                                var personLocation = new LocationService( rockContext )
+                                                        .Get( oauthUser.address.street1, oauthUser.address.street2,
+                                                            oauthUser.address.city, oauthUser.address.state, oauthUser.address.zip, oauthUser.address.country );
+                                if ( personLocation != null )
                                 {
-                                    Guid familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
-                                    GroupService groupService = new GroupService( rockContext );
-                                    GroupLocationService groupLocationService = new GroupLocationService( rockContext );
-                                    var family = groupService.Queryable().Where( g => g.GroupType.Guid == familyGroupTypeGuid && g.Members.Any( m => m.PersonId == person.Id ) ).FirstOrDefault();
+                                    Guid locationTypeGuid = Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid();
+                                    if ( locationTypeGuid != Guid.Empty )
+                                    {
+                                        Guid familyGroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid();
+                                        GroupService groupService = new GroupService( rockContext );
+                                        GroupLocationService groupLocationService = new GroupLocationService( rockContext );
+                                        var family = groupService.Queryable().Where( g => g.GroupType.Guid == familyGroupTypeGuid && g.Members.Any( m => m.PersonId == person.Id ) ).FirstOrDefault();
 
-                                    var groupLocation = new GroupLocation();
-                                    groupLocation.GroupId = family.Id;
-                                    groupLocationService.Add( groupLocation );
+                                        var groupLocation = new GroupLocation();
+                                        groupLocation.GroupId = family.Id;
+                                        groupLocationService.Add( groupLocation );
 
-                                    groupLocation.Location = personLocation;
+                                        groupLocation.Location = personLocation;
 
-                                    groupLocation.GroupLocationTypeValueId = DefinedValueCache.Get( locationTypeGuid ).Id;
-                                    groupLocation.IsMailingLocation = true;
-                                    groupLocation.IsMappedLocation = true;
+                                        groupLocation.GroupLocationTypeValueId = DefinedValueCache.Get( locationTypeGuid ).Id;
+                                        groupLocation.IsMailingLocation = true;
+                                        groupLocation.IsMappedLocation = true;
 
-                                    rockContext.SaveChanges();
+                                        rockContext.SaveChanges();
+                                    }
                                 }
                             }
                         }

--- a/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth" )]
 [assembly: AssemblyProduct( "rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2021" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.2.*" )]
+[assembly: AssemblyVersion( "2.3.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
+++ b/rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
@@ -41,9 +41,9 @@ namespace rocks.kfs.Workflow.Action.Communication
     #region Action Settings
 
     [TextField( "Message in Conversation", "Message to display in conversation as though it was from the recipient. Default: Blank <span class='tip tip-lava'></span>", false, "" )]
-    [BooleanField( "Mark as Read", "Flag indicating if the conversation should be marked as read when submitted. Default: No", defaultValue: false, order: 1 )]
-    [WorkflowAttribute( "Person", "The workflow attribute of the person to be the recipient.", true, "", "", 7, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
-    [DefinedValueField( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM, "SMS From Number", "The SMS number the conversation will appear under.", false, false )]
+    [BooleanField( "Mark as Read", "Flag indicating if the conversation should be marked as read when submitted. Default: No", defaultValue: false )]
+    [WorkflowAttribute( "Person", "The workflow attribute of the person to be the recipient.", true, "", "", 0, null, new string[] { "Rock.Field.Types.PersonFieldType" } )]
+    [DefinedValueField( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM, "SMS From Number", "The SMS number the conversation will appear under.", true, false, DisplayDescription = true )]
     #endregion
 
     /// <summary>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Update workflow action settings to be required, display descriptions (for from number), and update order.
- Add Null checks to DoorkeeperOAuth for address and birthday.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Update `SMS From Number` to be required.
- Update `SMS From Number` to display descriptions instead of values.
- Added Null checks to DoorkeeperOAuth for address and birthday.

---------

### Requested By

##### Who reported, requested, or paid for the change?

CBC-N, Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/194132712-9eeaafbd-0dfc-4dd6-ad32-bbf802fe5260.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Workflow.Action.Communication/AddSMSConversation.cs
- rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
