### PR TITLE
PostalServer Transport Component

### DIFF
--- a/KFSRock.sln.kfs
+++ b/KFSRock.sln.kfs
@@ -6,7 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "RockWeb", "RockWeb\", "{E43B5D55-BED0-4E74-BF97-9327F9A9D656}"
 	ProjectSection(WebsiteProperties) = preProject
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.5.2"
-		ProjectReferences = "{00edcb8d-ef33-459c-ad62-02876bd24dff}|DotLiquid.dll;{185a31d7-3037-4dae-8797-0459849a84bd}|Rock.dll;{d6b19c0d-da5e-4f75-8001-04ded86b741f}|Rock.Mailgun.dll;{cf8c694a-55a0-434f-bc96-3450b96ec12a}|Rock.Mandrill.dll;{704740d8-b539-4560-9f8c-681670c9d6ad}|Rock.Migrations.dll;{f3692909-952d-4c4a-b2d2-d90d0083cf53}|Rock.NMI.dll;{a005d091-140e-4ec4-bcdf-cf7d42bb702c}|Rock.PayFlowPro.dll;{add1edd0-a4cb-4e82-b6ad-6ad1d556deae}|Rock.Rest.dll;{6fe0930c-6832-4c2f-8a76-d4e4a2d80ddf}|Rock.Version.dll;{1f5956f2-2b0f-49b8-aaf1-2cc28f01426a}|Rock.SignNow.dll;{69AC175C-3997-4514-8C9E-5D24811928C2}|SignNowSDK.dll;{c1dd2402-5fb2-411e-bf8d-5d9cb3a58e8b}|Rock.Slingshot.dll;{962944DE-8BF4-4175-B55A-E75CF7918272}|Rock.Slingshot.Model.dll;{42edf2dd-5284-4b64-93c3-5186619d2b14}|Rock.StatementGenerator.dll;{5055f482-72c7-4cc9-8ed0-a77090c777db}|Rock.Security.Authentication.Auth0.dll;{515e22e4-4b9b-4886-8477-e5b312b75eb4}|Rock.WebStartup.dll;{94a5f880-31ae-4889-b9be-ba1fdc258e83}|Rock.Checkr.dll;{cadd9206-2c6b-42e4-b20b-2dfc3eb4d6d4}|Rock.DownhillCss.dll;{13711bed-69dd-4182-9bb5-b3c9a4de32df}|Rock.MyWell.dll;{205f439a-2ccc-42c1-b1ab-09e1b629d88c}|Rock.SendGrid.dll;{8ccb8e2a-073c-48cb-b31a-621ec5430a42}|Rock.Oidc.dll;{b62b27c8-1f77-43cf-8ee7-30de7f93facd}|Rock.Update.dll;{bc36cac2-1f25-4190-9297-157ddd2e4960}|cc.newspring.AttendedCheckIn.dll;{e3c37e39-0dae-4826-b38f-eb6a4d23842f}|com.centralaz.RoomManagement.dll;"
+		ProjectReferences = "{00edcb8d-ef33-459c-ad62-02876bd24dff}|DotLiquid.dll;{185a31d7-3037-4dae-8797-0459849a84bd}|Rock.dll;{d6b19c0d-da5e-4f75-8001-04ded86b741f}|Rock.Mailgun.dll;{cf8c694a-55a0-434f-bc96-3450b96ec12a}|Rock.Mandrill.dll;{704740d8-b539-4560-9f8c-681670c9d6ad}|Rock.Migrations.dll;{f3692909-952d-4c4a-b2d2-d90d0083cf53}|Rock.NMI.dll;{a005d091-140e-4ec4-bcdf-cf7d42bb702c}|Rock.PayFlowPro.dll;{add1edd0-a4cb-4e82-b6ad-6ad1d556deae}|Rock.Rest.dll;{6fe0930c-6832-4c2f-8a76-d4e4a2d80ddf}|Rock.Version.dll;{1f5956f2-2b0f-49b8-aaf1-2cc28f01426a}|Rock.SignNow.dll;{69AC175C-3997-4514-8C9E-5D24811928C2}|SignNowSDK.dll;{c1dd2402-5fb2-411e-bf8d-5d9cb3a58e8b}|Rock.Slingshot.dll;{962944DE-8BF4-4175-B55A-E75CF7918272}|Rock.Slingshot.Model.dll;{42edf2dd-5284-4b64-93c3-5186619d2b14}|Rock.StatementGenerator.dll;{5055f482-72c7-4cc9-8ed0-a77090c777db}|Rock.Security.Authentication.Auth0.dll;{515e22e4-4b9b-4886-8477-e5b312b75eb4}|Rock.WebStartup.dll;{94a5f880-31ae-4889-b9be-ba1fdc258e83}|Rock.Checkr.dll;{cadd9206-2c6b-42e4-b20b-2dfc3eb4d6d4}|Rock.DownhillCss.dll;{13711bed-69dd-4182-9bb5-b3c9a4de32df}|Rock.MyWell.dll;{205f439a-2ccc-42c1-b1ab-09e1b629d88c}|Rock.SendGrid.dll;{8ccb8e2a-073c-48cb-b31a-621ec5430a42}|Rock.Oidc.dll;{b62b27c8-1f77-43cf-8ee7-30de7f93facd}|Rock.Update.dll;{bc36cac2-1f25-4190-9297-157ddd2e4960}|cc.newspring.AttendedCheckIn.dll;"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_6229"
 		Debug.AspNetCompiler.PhysicalPath = "RockWeb\"
 		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_6229\"
@@ -151,11 +151,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Security.External
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalanche", "Avalanche\Plugin\Avalanche.csproj", "{DE6B9975-365C-4D0C-8CF9-8B7F5FDCD0D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "com.centralaz.RoomManagement", "CentralAZ\com.CentralAZ.RoomManagement\com.centralaz.RoomManagement.csproj", "{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Workflow.Action.Core", "KFSRockAssemblies\rocks.kfs.Workflow.Action.Core\rocks.kfs.Workflow.Action.Core.csproj", "{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.StepsToCare", "KFSRockAssemblies\rocks.kfs.StepsToCare\rocks.kfs.StepsToCare.csproj", "{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Shortcodes", "KFSRockAssemblies\rocks.kfs.Shortcodes\rocks.kfs.Shortcodes.csproj", "{EA104634-0BAA-402F-B901-E2016990237E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Checkin.PagerEntry", "KFSRockAssemblies\rocks.kfs.Checkin.PagerEntry\rocks.kfs.Checkin.PagerEntry.csproj", "{86F7A34A-D1AF-444D-9245-75760F97D469}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Zoom", "KFSRockAssemblies\rocks.kfs.Zoom\rocks.kfs.Zoom.csproj", "{2E6CA020-205D-4FB8-AD08-91866D653C4B}"
 EndProject
@@ -164,6 +166,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.GroupRoundRobinAssignment", "KFSRockAssemblies\rocks.kfs.GroupRoundRobinAssignment\rocks.kfs.GroupRoundRobinAssignment.csproj", "{E2040E07-572B-4629-8B9F-6B53EC7C077C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.CustomGroupCommunication", "KFSRockAssemblies\rocks.kfs.CustomGroupCommunication\rocks.kfs.CustomGroupCommunication.csproj", "{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Workflow.Action.Communication", "KFSRockAssemblies\rocks.kfs.Workflow.Action.Communication\rocks.kfs.Workflow.Action.Communication.csproj", "{1832B422-27F0-11ED-A261-0242AC120002}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.PostalServer", "KFSRockAssemblies\rocks.kfs.PostalServer\rocks.kfs.PostalServer.csproj", "{0D13E326-BBB8-4834-A5A8-EC0448F0F232}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Edify", "KFSRockAssemblies\rocks.kfs.Edify\rocks.kfs.Edify.csproj", "{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -231,10 +239,6 @@ Global
 		{962944DE-8BF4-4175-B55A-E75CF7918272}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{962944DE-8BF4-4175-B55A-E75CF7918272}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{962944DE-8BF4-4175-B55A-E75CF7918272}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5BC16478-A45D-4F65-87B2-FFD61650D541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5BC16478-A45D-4F65-87B2-FFD61650D541}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5BC16478-A45D-4F65-87B2-FFD61650D541}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5BC16478-A45D-4F65-87B2-FFD61650D541}.Release|Any CPU.Build.0 = Release|Any CPU
 		{42EDF2DD-5284-4B64-93C3-5186619D2B14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{42EDF2DD-5284-4B64-93C3-5186619D2B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42EDF2DD-5284-4B64-93C3-5186619D2B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -419,10 +423,6 @@ Global
 		{DE6B9975-365C-4D0C-8CF9-8B7F5FDCD0D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE6B9975-365C-4D0C-8CF9-8B7F5FDCD0D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE6B9975-365C-4D0C-8CF9-8B7F5FDCD0D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E3C37E39-0DAE-4826-B38F-EB6A4D23842F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CDCD152-1CDA-4A9A-9B22-22AD9316EFB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -431,6 +431,14 @@ Global
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44B89D21-5AF4-4E89-A49D-31B60EC4AB4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA104634-0BAA-402F-B901-E2016990237E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA104634-0BAA-402F-B901-E2016990237E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA104634-0BAA-402F-B901-E2016990237E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA104634-0BAA-402F-B901-E2016990237E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86F7A34A-D1AF-444D-9245-75760F97D469}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86F7A34A-D1AF-444D-9245-75760F97D469}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86F7A34A-D1AF-444D-9245-75760F97D469}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86F7A34A-D1AF-444D-9245-75760F97D469}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E6CA020-205D-4FB8-AD08-91866D653C4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -447,6 +455,18 @@ Global
 		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1832B422-27F0-11ED-A261-0242AC120002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1832B422-27F0-11ED-A261-0242AC120002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1832B422-27F0-11ED-A261-0242AC120002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1832B422-27F0-11ED-A261-0242AC120002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D13E326-BBB8-4834-A5A8-EC0448F0F232}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D13E326-BBB8-4834-A5A8-EC0448F0F232}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D13E326-BBB8-4834-A5A8-EC0448F0F232}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D13E326-BBB8-4834-A5A8-EC0448F0F232}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -85,7 +85,7 @@ namespace rocks.kfs.Edify.Communications.Transport
             var bccEmailList = new List<string>();
             var attachments = new List<MessageAttachment>();
 
-            string sender = null;
+            string sender = rockEmailMessage.FromEmail;
             string replyTo = null;
             string tag = null;
 
@@ -135,6 +135,7 @@ namespace rocks.kfs.Edify.Communications.Transport
 
             try
             {
+                // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
                 var response = client.SendMessage( rockEmailMessage.FromEmail, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
                 return new EmailSendResponse
                 {

--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -26,28 +26,31 @@ using Rock.Attribute;
 using Rock.Communication;
 using Rock.Communication.Transport;
 using Rock.Model;
+using Rock.Web.Cache;
 
-namespace rocks.kfs.PostalServer.Communications.Transport
+namespace rocks.kfs.Edify.Communications.Transport
 {
     /// <summary>
-    /// Used to send communication through Postal Server's HTTP API.
+    /// Used to send communication through Edify's HTTP API.
     /// </summary>
     /// <seealso cref="Rock.Communication.EmailTransportComponent" />
-    [Description( "Sends a communication through Postal Server's HTTP API" )]
+    [Description( "Sends a communication through Edify's HTTP API" )]
     [Export( typeof( TransportComponent ) )]
-    [ExportMetadata( "ComponentName", "Postal Server HTTP" )]
-    [TextField( "Base URL",
-        Description = "The API URL provided by Postal Server, generally the server url you use to login to the Postal Server with '/api/v1' appended.",
+    [ExportMetadata( "ComponentName", "Edify HTTP" )]
+    [DefinedValueField( "Base URL",
+        Description = "The API URL provided by Edify.",
+        DefinedTypeGuid = SystemGuid.BASE_URL_DEFINED_TYPE,
+        DisplayDescription = true,
         IsRequired = true,
-        DefaultValue = @"",
+        DefaultValue = SystemGuid.BASE_URL_SERVER1,
         Order = 0,
         Key = AttributeKey.BaseUrl )]
     [TextField( "API Key",
-        Description = "The API Key provided by Postal Server API Credentials.",
+        Description = "The API Key provided by Edify API Credentials.",
         IsRequired = true,
         Order = 1,
         Key = AttributeKey.ApiKey )]
-    public class PostalServerHTTP : EmailTransportComponent
+    public class EdifyHTTP : EmailTransportComponent
     {
         /// <summary>
         /// Class for storing attribute keys.
@@ -66,13 +69,16 @@ namespace rocks.kfs.PostalServer.Communications.Transport
         }
 
         /// <summary>
-        /// Send the Postal Server specific email. 
+        /// Send the Edify specific email. 
         /// </summary>
         /// <param name="rockEmailMessage">The rock email message.</param>
         /// <returns></returns>
         protected override EmailSendResponse SendEmail( RockEmailMessage rockEmailMessage )
         {
-            var client = new PostalServerDotNet.v1.Client( GetAttributeValue( AttributeKey.BaseUrl ), GetAttributeValue( AttributeKey.ApiKey ) );
+            var selectedBaseUrlGuid = GetAttributeValue( AttributeKey.BaseUrl ).AsGuid();
+            var definedValueBaseUrl = DefinedValueCache.Get( selectedBaseUrlGuid );
+            var baseUrl = $"https://{definedValueBaseUrl.Value}.edify.press/api/v1";
+            var client = new PostalServerDotNet.v1.Client( baseUrl, GetAttributeValue( AttributeKey.ApiKey ) );
 
             var toEmailList = new List<string>();
             var ccEmailList = new List<string>();

--- a/rocks.kfs.Edify/Migrations/001_CreateDefinedTypes.cs
+++ b/rocks.kfs.Edify/Migrations/001_CreateDefinedTypes.cs
@@ -1,0 +1,38 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.Edify.Migrations
+{
+    [MigrationNumber( 1, "1.12.3" )]
+    public class CreateDefinedTypes : Migration
+    {
+        public override void Up()
+        {
+            RockMigrationHelper.AddDefinedType( "Communication", "Edify Server", "Edify servers available to choose from in the Communication transport.", SystemGuid.BASE_URL_DEFINED_TYPE );
+            RockMigrationHelper.UpdateDefinedValue( SystemGuid.BASE_URL_DEFINED_TYPE, "e1", "Edify Server 1 (e1)", SystemGuid.BASE_URL_SERVER1, true );
+            RockMigrationHelper.UpdateDefinedValue( SystemGuid.BASE_URL_DEFINED_TYPE, "e2", "Edify Server 2 (e2)", SystemGuid.BASE_URL_SERVER2, true );
+        }
+
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteDefinedValue( SystemGuid.BASE_URL_SERVER2 ); // Server 2
+            RockMigrationHelper.DeleteDefinedValue( SystemGuid.BASE_URL_SERVER1 ); // Server 1
+            RockMigrationHelper.DeleteDefinedType( SystemGuid.BASE_URL_DEFINED_TYPE ); // Status
+        }
+    }
+}

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -1,0 +1,50 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "rocks.kfs.Edify" )]
+[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "Kingdom First Solutions" )]
+[assembly: AssemblyProduct( "rocks.kfs.Edify" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "9FD4BFBA-B6F2-47CD-A68A-4048687362DF" )]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+[assembly: AssemblyVersion( "1.0.*" )]

--- a/rocks.kfs.Edify/SystemGuid.cs
+++ b/rocks.kfs.Edify/SystemGuid.cs
@@ -1,0 +1,9 @@
+﻿namespace rocks.kfs.Edify
+{
+    public class SystemGuid
+    {
+        public const string BASE_URL_DEFINED_TYPE = "C63B4D0E-C113-4DDF-82A0-437BA172301B";
+        public const string BASE_URL_SERVER1 = "2F6A3E45-586C-4813-B84C-62C1146D32AC";
+        public const string BASE_URL_SERVER2 = "D150131C-59B8-4334-9DE2-EE3CC274FEDE";
+    }
+}

--- a/rocks.kfs.Edify/packages.config
+++ b/rocks.kfs.Edify/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="PostalServerDotNet" version="1.0.8312.28336" targetFramework="net452" />
+</packages>

--- a/rocks.kfs.Edify/packages.config
+++ b/rocks.kfs.Edify/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="PostalServerDotNet" version="1.0.8312.28336" targetFramework="net452" />
+  <package id="PostalServerDotNet" version="1.1.8319.31316" targetFramework="net452" />
 </packages>

--- a/rocks.kfs.Edify/rocks.kfs.Edify.csproj
+++ b/rocks.kfs.Edify/rocks.kfs.Edify.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9FD4BFBA-B6F2-47CD-A68A-4048687362DF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>rocks.kfs.Edify</RootNamespace>
+    <AssemblyName>rocks.kfs.Edify</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PostalServerDotNet, Version=1.0.8312.28336, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PostalServerDotNet.1.0.8312.28336\lib\net452\PostalServerDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Communications\Transport\EdifyHTTP.cs" />
+    <Compile Include="Migrations\001_CreateDefinedTypes.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemGuid.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R "$(TargetPath)" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(TargetDir)$(TargetName).pdb" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(ProjectDir)bin\Debug\PostalServerDotNet.dll" "$(SolutionDir)RockWeb\bin"
+</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/rocks.kfs.Edify/rocks.kfs.Edify.csproj
+++ b/rocks.kfs.Edify/rocks.kfs.Edify.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="PostalServerDotNet, Version=1.0.8312.28336, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PostalServerDotNet.1.0.8312.28336\lib\net452\PostalServerDotNet.dll</HintPath>
+    <Reference Include="PostalServerDotNet, Version=1.1.8319.31316, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PostalServerDotNet.1.1.8319.31316\lib\net452\PostalServerDotNet.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -40,6 +40,10 @@
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="UAParser, Version=3.1.44.0, Culture=neutral, PublicKeyToken=f7377bf021646069, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\UAParser.dll</HintPath>
     </Reference>
     <Reference Include="Rock">
       <SpecificVersion>False</SpecificVersion>
@@ -50,7 +54,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />

--- a/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
+++ b/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
@@ -79,7 +79,7 @@ namespace rocks.kfs.PostalServer.Communications.Transport
             var bccEmailList = new List<string>();
             var attachments = new List<MessageAttachment>();
 
-            string sender = null;
+            string sender = rockEmailMessage.FromEmail;
             string replyTo = null;
             string tag = null;
 

--- a/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
+++ b/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
@@ -1,0 +1,186 @@
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using PostalServerDotNet.v1.Model.Object;
+using Rock;
+using Rock.Attribute;
+using Rock.Communication;
+using Rock.Communication.Transport;
+using Rock.Model;
+
+namespace rocks.kfs.PostalServer.Communications.Transport
+{
+    /// <summary>
+    /// Used to send communication through Postal Server's HTTP API.
+    /// </summary>
+    /// <seealso cref="Rock.Communication.EmailTransportComponent" />
+    [Description( "Sends a communication through Postal Server's HTTP API" )]
+    [Export( typeof( TransportComponent ) )]
+    [ExportMetadata( "ComponentName", "Postal Server HTTP" )]
+    [TextField( "Base URL",
+        Description = "The API URL provided by Postal Server, generally the server url you use to login to the Postal Server with '/api/v1' appended.",
+        IsRequired = true,
+        DefaultValue = @"",
+        Order = 0,
+        Key = AttributeKey.BaseUrl )]
+    [TextField( "API Key",
+        Description = "The API Key provided by Postal Server API Credentials.",
+        IsRequired = true,
+        Order = 3,
+        Key = AttributeKey.ApiKey )]
+    [BooleanField( "Track Opens",
+        Description = "Allow Postal Server to track opens, clicks, and unsubscribes.",
+        DefaultValue = "true",
+        Order = 4,
+        Key = AttributeKey.TrackOpens )]
+    public class PostalServerHTTP : EmailTransportComponent
+    {
+        /// <summary>
+        /// Class for storing attribute keys.
+        /// </summary>
+        public class AttributeKey
+        {
+            /// <summary>
+            /// The track opens
+            /// </summary>
+            public const string TrackOpens = "TrackOpens";
+
+            /// <summary>
+            /// The API key
+            /// </summary>
+            public const string ApiKey = "APIKey";
+
+            /// <summary>
+            /// The base URL
+            /// </summary>
+            public const string BaseUrl = "BaseURL";
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether transport has ability to track recipients opening the communication.
+        /// Postal Server automatically tracks opens, clicks, and unsubscribes. Use this to override domain setting.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if transport can track opens; otherwise, <c>false</c>.
+        /// </value>
+        public override bool CanTrackOpens
+        {
+            get { return GetAttributeValue( AttributeKey.TrackOpens ).AsBoolean( true ); }
+        }
+
+        /// <summary>
+        /// Send the implementation specific email. This class will call this method and pass the post processed data in a rock email message which
+        /// can then be used to send the implementation specific message.
+        /// </summary>
+        /// <param name="rockEmailMessage">The rock email message.</param>
+        /// <returns></returns>
+        protected override EmailSendResponse SendEmail( RockEmailMessage rockEmailMessage )
+        {
+            var client = new PostalServerDotNet.v1.Client( GetAttributeValue( AttributeKey.BaseUrl ), GetAttributeValue( AttributeKey.ApiKey ) );
+
+            var toEmailList = new List<string>();
+            var ccEmailList = new List<string>();
+            var bccEmailList = new List<string>();
+            var attachments = new List<MessageAttachment>();
+
+            string sender = null;
+            string replyTo = null;
+            string tag = null;
+
+            // To
+            var toEmail = rockEmailMessage.GetRecipients();
+            toEmail.ForEach( r => toEmailList.Add( r.To ) );
+
+            if ( rockEmailMessage.ReplyToEmail.IsNotNullOrWhiteSpace() )
+            {
+                replyTo = rockEmailMessage.ReplyToEmail;
+            }
+
+            // CC
+            var ccEmailAddresses = rockEmailMessage
+                .CCEmails
+                .Where( cc => cc != string.Empty )
+                .Where( cc => !toEmail.Any( te => te.To == cc ) )
+                .ToList();
+
+            // BCC
+            var bccEmailAddresses = rockEmailMessage
+                .BCCEmails
+                .Where( bcc => bcc != string.Empty )
+                .Where( bcc => !toEmail.Any( te => te.To == bcc ) )
+                .Where( bcc => !ccEmailAddresses.Contains( bcc ) )
+                .ToList();
+
+            // Communication record for tracking opens & clicks
+            if ( rockEmailMessage.MessageMetaData != null && rockEmailMessage.MessageMetaData.Count > 0 )
+            {
+                tag = rockEmailMessage.MessageMetaData.Join( "|" );
+            }
+
+            if ( CanTrackOpens )
+            {
+                //ToDo, what do we need to do to enable or disable tracking via the api, can we?
+            }
+
+            // Attachments
+            if ( rockEmailMessage.Attachments.Any() )
+            {
+                foreach ( var attachment in rockEmailMessage.Attachments )
+                {
+                    if ( attachment != null )
+                    {
+                        MessageAttachment ma = new MessageAttachment();
+                        MemoryStream ms = new MemoryStream();
+                        attachment.ContentStream.CopyTo( ms );
+                        ma.Data = Convert.ToBase64String( ms.ToArray() );
+                        ma.Name = attachment.FileName;
+                        ma.Content_Type = attachment.MimeType;
+                        attachments.Add( ma );
+                    }
+                }
+            }
+
+            // Send it
+            try
+            {
+                var response = client.SendMessage( rockEmailMessage.FromEmail, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
+                return new EmailSendResponse
+                {
+                    Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,
+                    StatusNote = response.Status
+                };
+            }
+            catch ( Exception e )
+            {
+                if ( e.InnerException != null )
+                {
+                    throw e;
+                }
+                return new EmailSendResponse
+                {
+                    Status = CommunicationRecipientStatus.Failed,
+                    StatusNote = e.Message
+                };
+            }
+        }
+    }
+}

--- a/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿// <copyright>
+// Copyright 2022 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "rocks.kfs.PostalServer" )]
+[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "Kingdom First Solutions" )]
+[assembly: AssemblyProduct( "rocks.kfs.PostalServer" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "0d13e326-bbb8-4834-a5a8-ec0448f0f232" )]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+[assembly: AssemblyVersion( "1.0.*" )]

--- a/rocks.kfs.PostalServer/packages.config
+++ b/rocks.kfs.PostalServer/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="PostalServerDotNet" version="1.0.8312.28336" targetFramework="net452" />
+</packages>

--- a/rocks.kfs.PostalServer/packages.config
+++ b/rocks.kfs.PostalServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="PostalServerDotNet" version="1.0.8312.28336" targetFramework="net452" />
+  <package id="PostalServerDotNet" version="1.1.8319.31316" targetFramework="net452" />
 </packages>

--- a/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
+++ b/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
@@ -34,14 +34,18 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PostalServerDotNet, Version=1.0.8312.28336, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PostalServerDotNet.1.0.8312.28336\lib\net452\PostalServerDotNet.dll</HintPath>
+    <Reference Include="PostalServerDotNet, Version=1.1.8319.31316, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PostalServerDotNet.1.1.8319.31316\lib\net452\PostalServerDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Rock">
+    <Reference Include="UAParser, Version=3.1.44.0, Culture=neutral, PublicKeyToken=f7377bf021646069, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\UAParser.dll</HintPath>
+    </Reference>
+	<Reference Include="Rock">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
     </Reference>
@@ -50,7 +54,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />

--- a/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
+++ b/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0D13E326-BBB8-4834-A5A8-EC0448F0F232}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>rocks.kfs.PostalServer</RootNamespace>
+    <AssemblyName>rocks.kfs.PostalServer</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PostalServerDotNet, Version=1.0.8312.28336, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PostalServerDotNet.1.0.8312.28336\lib\net452\PostalServerDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Communications\Transport\PostalServerHTTP.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R "$(TargetPath)" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(TargetDir)$(TargetName).pdb" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(ProjectDir)bin\Debug\PostalServerDotNet.dll" "$(SolutionDir)RockWeb\bin"
+</PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Create Postal Server transport component for Rock via Postal Server API. As well as an Edify.contact specific transport component.

**New Settings:**

- Base URL
- API Key

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- New Rock Transport Component built for Postal Server API
- New Rock Transport Component built for Edify API

---------

### Requested By

##### Who reported, requested, or paid for the change?

Edify.contact

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/194670328-0f37b98f-ae73-4f7b-8c92-dab82cc8be15.png)

![image](https://user-images.githubusercontent.com/2990519/195192608-7a898ea1-9ae2-476d-8ec6-c1d83420850f.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
- rocks.kfs.Edify/Migrations/001_CreateDefinedTypes.cs
- rocks.kfs.Edify/Properties/AssemblyInfo.cs
- rocks.kfs.Edify/SystemGuid.cs
- rocks.kfs.Edify/packages.config
- rocks.kfs.Edify/rocks.kfs.Edify.csproj
- rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
- rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
- rocks.kfs.PostalServer/packages.config
- rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
