### PR TITLE
Doorkeeper Phone Number Null Fix

### DIFF
--- a/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs
+++ b/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs
@@ -488,9 +488,12 @@ namespace com.kfs.Security.ExternalAuthentication
                             person.EmailPreference = EmailPreference.EmailAllowed;
                             person.Gender = Gender.Unknown;
 
-                            var phoneNumber = new PhoneNumber { NumberTypeValueId = phoneNumberTypeId };
-                            person.PhoneNumbers.Add( phoneNumber );
-                            phoneNumber.Number = PhoneNumber.CleanNumber( oauthUser.contact.phone.AsNumeric() );
+                            if ( oauthUser.contact != null && !string.IsNullOrWhiteSpace( oauthUser.contact.phone ) )
+                            {
+                                var phoneNumber = new PhoneNumber { NumberTypeValueId = phoneNumberTypeId };
+                                person.PhoneNumbers.Add( phoneNumber );
+                                phoneNumber.Number = PhoneNumber.CleanNumber( oauthUser.contact.phone.AsNumeric() );
+                            }
 
                             if ( oauthUser.contact != null && !string.IsNullOrWhiteSpace( oauthUser.contact.birthday ) )
                             {

--- a/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.3.*" )]
+[assembly: AssemblyVersion( "2.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add protection for phone number field potentially being null as well.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Add protection for phone number field potentially being null as well.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Watermark

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Security.ExternalAuthentication.DoorkeeperOAuth/DoorkeeperOAuth.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
