### PR TITLE
Update From on Edify and Postal to include FromName.

### DIFF
--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -86,6 +86,10 @@ namespace rocks.kfs.Edify.Communications.Transport
             var attachments = new List<MessageAttachment>();
 
             string sender = rockEmailMessage.FromEmail;
+            if ( rockEmailMessage.FromName.IsNotNullOrWhiteSpace() && rockEmailMessage.FromName != rockEmailMessage.FromEmail )
+            {
+                sender = $"{rockEmailMessage.FromName} <{rockEmailMessage.FromEmail}>";
+            }
             string replyTo = null;
             string tag = null;
 
@@ -136,7 +140,7 @@ namespace rocks.kfs.Edify.Communications.Transport
             try
             {
                 // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
-                var response = client.SendMessage( rockEmailMessage.FromEmail, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
+                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
                 return new EmailSendResponse
                 {
                     Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]

--- a/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
+++ b/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
@@ -80,6 +80,10 @@ namespace rocks.kfs.PostalServer.Communications.Transport
             var attachments = new List<MessageAttachment>();
 
             string sender = rockEmailMessage.FromEmail;
+            if ( rockEmailMessage.FromName.IsNotNullOrWhiteSpace() && rockEmailMessage.FromName != rockEmailMessage.FromEmail )
+            {
+                sender = $"{rockEmailMessage.FromName} <{rockEmailMessage.FromEmail}>";
+            }
             string replyTo = null;
             string tag = null;
 
@@ -129,7 +133,7 @@ namespace rocks.kfs.PostalServer.Communications.Transport
 
             try
             {
-                var response = client.SendMessage( rockEmailMessage.FromEmail, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
+                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
                 return new EmailSendResponse
                 {
                     Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,

--- a/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.PostalServer/Properties/AssemblyInfo.cs
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added support for From Name that should have already been there but was missed.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added support for From Name field for Edify and Postal Server

---------

### Requested By

##### Who reported, requested, or paid for the change?

Edify

---------

### Screenshots

##### Does this update or add options to the block UI?

Before:   
<img width="250" alt="image" src="https://user-images.githubusercontent.com/2990519/199110502-a0d4b2eb-2170-4ba3-9f3b-96e2b95c13a4.png">

After:   
<img width="281" alt="image" src="https://user-images.githubusercontent.com/2990519/199110388-081bdd37-0e99-4a64-99c7-c9aeacaf5765.png">


---------

### Change Log

##### What files does it affect?

- rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
- rocks.kfs.Edify/Properties/AssemblyInfo.cs
- rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
- rocks.kfs.PostalServer/Properties/AssemblyInfo.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
