### PR TITLE
Workers Only Assignment Fix

### DIFF
--- a/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedProcesses.cs
+++ b/rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedProcesses.cs
@@ -542,7 +542,7 @@ namespace rocks.kfs.StepsToCare.Jobs
 
             foreach ( var careNeed in unassignedCareNeeds )
             {
-                CareUtilities.AutoAssignWorkers( careNeed, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
+                CareUtilities.AutoAssignWorkers( careNeed, careNeed.WorkersOnly, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
 
                 if ( careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
                 {
@@ -556,7 +556,7 @@ namespace rocks.kfs.StepsToCare.Jobs
                         }
                         else
                         {
-                            CareUtilities.AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only", autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
+                            CareUtilities.AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only" || careNeed.WorkersOnly, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                         }
                     }
                 }

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.5.*" )]
+[assembly: AssemblyVersion( "1.6.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Round robin assignment only (Care Workers) when "Workers only" is checked for future needs.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed issue when "Workers Only" is selected only workers should be assigned through the round robin assignment, no small group leaders or "geofence"/deacon workers.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.StepsToCare/Jobs/CareNeedAutomatedProcesses.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
