### PR TITLE
Edify Fix for Attachments

### DIFF
--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -140,7 +140,7 @@ namespace rocks.kfs.Edify.Communications.Transport
             try
             {
                 // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
-                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
+                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, ( !attachments.Any() ) ? rockEmailMessage.PlainTextMessage : "", rockEmailMessage.Message, attachments );
                 return new EmailSendResponse
                 {
                     Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for Edify if there are attachments don't include Plain Body.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed issue where an attachment would take over the email in Mac mail and iOS mail in Edify.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
