### PR TITLE
Add Impersonation Settings to EWS shortcode and job

### DIFF
--- a/rocks.kfs.Shortcodes/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Shortcodes/Properties/AssemblyInfo.cs
@@ -48,4 +48,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]


### PR DESCRIPTION
**Thank you for your code contribution, we will take your code suggestion into consideration. It will be reviewed, and based on code quality and need addressed, we will determine acceptance. If this code addresses a feature request or issue, be sure to link to that issue.** 

### Description 

##### What does the change add or fix?

Previous update to use OAuth authentication only allowed for the EWS api tools to impersonate the same mailbox it was trying to access. This prevented the tools from accessing groups. A separate "Impersonate" setting was added to both the shortcode and the job settings to allow configuration of the specific Microsoft365 user account to have the application impersonate.

**New Lava Shortcode Filter Settings:**
* impersonate

**New WorkflowFromEWS Job Settings:**
* Impersonate User

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added "Impersonate" setting to EWS Calendar Items lava shortcode to set the Microsoft365 user account for the application to impersonate.
* Added "Impersonate User" setting to Start Workflow (WorkflowFromEWS) job to set the Microsoft365 user account for the application to impersonate.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

New Impersonate User job setting:
![image](https://user-images.githubusercontent.com/7374281/203602356-ff4dbde5-8e79-4951-affd-29b75c5cef1f.png)


---------

### Change Log

##### What files does it affect?

* rocks.kfs.Shortcodes/EWS/CalendarItems.cs
* rocks.kfs.Shortcodes/Properties/AssemblyInfo.cs
* rocks.kfs.WorkflowFromEWS/Jobs/StartWorkflow.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
