### PR TITLE
ShelbyFinancials - Fix AttributeValue migration to be Rock v14 compatible

### DIFF
--- a/rocks.kfs.ShelbyFinancials/Migrations/002_AddDebitAccountSub.cs
+++ b/rocks.kfs.ShelbyFinancials/Migrations/002_AddDebitAccountSub.cs
@@ -67,6 +67,17 @@ namespace rocks.kfs.ShelbyFinancials.Migrations
                 DECLARE @DebAccSubAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '4F1BA61A-31C3-4FD6-9758-E3FE17A2D746' )
 
                 INSERT INTO [AttributeValue]
+                   ([IsSystem]
+                   ,[AttributeId]
+                   ,[EntityId]
+                   ,[Value]
+                   ,[Guid]
+                   ,[CreatedDateTime]
+                   ,[ModifiedDateTime]
+                   ,[CreatedByPersonAliasId]
+                   ,[ModifiedByPersonAliasId]
+                   ,[ValueAsNumeric])
+
                 SELECT AV.[IsSystem], 
                     @DebAccSubAttrId, 
                     AV.[EntityId], 
@@ -76,10 +87,6 @@ namespace rocks.kfs.ShelbyFinancials.Migrations
                     AV.[ModifiedDateTime], 
                     AV.[CreatedByPersonAliasId],
                     AV.[ModifiedByPersonAliasId],
-                    NULL,
-                    NULL,
-                    NULL,
-                    NULL,
                     AV.[ValueAsNumeric]
                 FROM AttributeValue AV WITH(NOLOCK)
                 LEFT JOIN AttributeValue AV2 WITH(NOLOCK) ON AV.EntityId = AV2.EntityId AND AV2.AttributeId = @DebAccSubAttrId 

--- a/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.3.*" )]
+[assembly: AssemblyVersion( "2.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Migration number 2 for this plugin has a SQL command that potentially inserts AttributeValues for a newly created attribute. The structure of the AttributeValue table added new columns in v14 of Rock that this insert statement did not account for. The INSERT statement has been modified to use explicit column definitions, making it more robust towards potential minor structure changes in the future.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fix bug causing exception during plugin migration in Rock v14.

---------

### Requested By

##### Who reported, requested, or paid for the change?

College Church

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* rocks.kfs.ShelbyFinancials/Migrations/002_AddDebitAccountSub.cs  

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
