### PR TITLE
Edify - Handle Empty lists

### DIFF
--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -139,13 +139,20 @@ namespace rocks.kfs.Edify.Communications.Transport
 
             try
             {
-                // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
-                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, ( !attachments.Any() ) ? rockEmailMessage.PlainTextMessage : "", rockEmailMessage.Message, attachments );
-                return new EmailSendResponse
+                if ( toEmailList.Any( e => e.Trim() != "" ) || ccEmailList.Any( e => e.Trim() != "" ) || bccEmailList.Any( e => e.Trim() != "" ) )
                 {
-                    Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,
-                    StatusNote = "Message Sent"
-                };
+                    // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
+                    var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, ( !attachments.Any() ) ? rockEmailMessage.PlainTextMessage : "", rockEmailMessage.Message, attachments );
+                    return new EmailSendResponse
+                    {
+                        Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,
+                        StatusNote = "Message Sent"
+                    };
+                }
+                else
+                {
+                    throw new Exception( "No Recipients found for this message." );
+                }
             }
             catch ( Exception e )
             {

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.2.*" )]
+[assembly: AssemblyVersion( "1.3.*" )]

--- a/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
+++ b/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
@@ -133,12 +133,20 @@ namespace rocks.kfs.PostalServer.Communications.Transport
 
             try
             {
-                var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, rockEmailMessage.PlainTextMessage, rockEmailMessage.Message, attachments );
-                return new EmailSendResponse
+                if ( toEmailList.Any( e => e.Trim() != "" ) || ccEmailList.Any( e => e.Trim() != "" ) || bccEmailList.Any( e => e.Trim() != "" ) )
                 {
-                    Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,
-                    StatusNote = "Message Sent"
-                };
+                    // Future enhancement possibility to convert Rock HTML Message to a readable Plain Text Message
+                    var response = client.SendMessage( sender, toEmailList, ccEmailList, bccEmailList, sender, rockEmailMessage.Subject, tag, replyTo, ( !attachments.Any() ) ? rockEmailMessage.PlainTextMessage : "", rockEmailMessage.Message, attachments );
+                    return new EmailSendResponse
+                    {
+                        Status = response.Status == "success" ? CommunicationRecipientStatus.Delivered : CommunicationRecipientStatus.Failed,
+                        StatusNote = "Message Sent"
+                    };
+                }
+                else
+                {
+                    throw new Exception( "No Recipients found for this message." );
+                }
             }
             catch ( Exception e )
             {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added an if statement to check for empty email address lists before sending, as apparently the api does accept a list of empty email addresses, just not a null list. Rock does most handling of empty email addresses when it is sent via a communication, but there are some areas in Rock that just adds a recipient even if they don't have an email address, such as the Get Scheduled Payments Job. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an issue where Edify transport could send an empty recipient list to the API.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty, Reported by CCIW

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
- rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
