### PR TITLE
Edify CC/BCC Fix

### DIFF
--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,17 +101,17 @@ namespace rocks.kfs.Edify.Communications.Transport
             var toEmail = rockEmailMessage.GetRecipients();
             toEmail.ForEach( r => toEmailList.Add( r.To ) );
 
-            var ccEmailAddresses = rockEmailMessage
+            ccEmailList = rockEmailMessage
                 .CCEmails
                 .Where( cc => cc != string.Empty )
                 .Where( cc => !toEmail.Any( te => te.To == cc ) )
                 .ToList();
 
-            var bccEmailAddresses = rockEmailMessage
+            bccEmailList = rockEmailMessage
                 .BCCEmails
                 .Where( bcc => bcc != string.Empty )
                 .Where( bcc => !toEmail.Any( te => te.To == bcc ) )
-                .Where( bcc => !ccEmailAddresses.Contains( bcc ) )
+                .Where( bcc => !ccEmailList.Contains( bcc ) )
                 .ToList();
 
             // Tag Communication record for tracking opens & clicks

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "Kingdom First Solutions" )]
 [assembly: AssemblyProduct( "rocks.kfs.Edify" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.3.*" )]
+[assembly: AssemblyVersion( "1.4.*" )]

--- a/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
+++ b/rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs
@@ -95,17 +95,17 @@ namespace rocks.kfs.PostalServer.Communications.Transport
             var toEmail = rockEmailMessage.GetRecipients();
             toEmail.ForEach( r => toEmailList.Add( r.To ) );
 
-            var ccEmailAddresses = rockEmailMessage
+            ccEmailList = rockEmailMessage
                 .CCEmails
                 .Where( cc => cc != string.Empty )
                 .Where( cc => !toEmail.Any( te => te.To == cc ) )
                 .ToList();
 
-            var bccEmailAddresses = rockEmailMessage
+            bccEmailList = rockEmailMessage
                 .BCCEmails
                 .Where( bcc => bcc != string.Empty )
                 .Where( bcc => !toEmail.Any( te => te.To == bcc ) )
-                .Where( bcc => !ccEmailAddresses.Contains( bcc ) )
+                .Where( bcc => !ccEmailList.Contains( bcc ) )
                 .ToList();
 
             // Tag Communication record for tracking opens & clicks


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed incorrect variable for CC and BCC Email lists sent to Edify.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed incorrect variable for CC and BCC Email lists sent to Edify.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
- rocks.kfs.Edify/Properties/AssemblyInfo.cs
- rocks.kfs.PostalServer/Communications/Transport/PostalServerHTTP.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
