### PR TITLE
Workflow from EWS changes

### DIFF
--- a/rocks.kfs.WorkflowFromEWS/Jobs/LaunchWorkflowFromEWSAccount.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/LaunchWorkflowFromEWSAccount.cs
@@ -93,7 +93,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
 
     [BooleanField( "One Workflow Per Conversation",
         Description = "If a workflow has already been created for a message in this conversation, additional workflows be not created. For example, replies will not activate new workflows.",
-        DefaultBooleanValue = false,
+        DefaultBooleanValue = true,
         Order = 10,
         Key = AttributeKey.OneWorkflowPerConversation )]
 

--- a/rocks.kfs.WorkflowFromEWS/Jobs/LaunchWorkflowFromEWSAccount.cs
+++ b/rocks.kfs.WorkflowFromEWS/Jobs/LaunchWorkflowFromEWSAccount.cs
@@ -79,7 +79,7 @@ namespace rocks.kfs.WorkflowFromEWS.Jobs
         Key = AttributeKey.LaunchWorkflowsWith )]
 
     [EnumsField( "Mark Processed Emails by",
-        Description = "How should the emails be marked within EWS once they are processed. Default: Read (Note: not all options will work without appropriate permissions. Multiple options will perform all that it can in order presented.).",
+        Description = "How should the emails be marked within EWS once they are processed. Default: Read (Note: not all options will work without appropriate permissions. Multiple options will perform all that it can in order presented.)",
         DefaultValue = "0",
         EnumSourceType = typeof( MarkEmailBy ),
         Order = 8,

--- a/rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.WorkflowFromEWS" )]
 [assembly: AssemblyProduct( "rocks.kfs.WorkflowFromEWS" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj
+++ b/rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj
@@ -70,7 +70,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Jobs\StartWorkflow.cs" />
+    <Compile Include="Jobs\LaunchWorkflowFromEWSAccount.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Updated to Rock coding standards for job settings
- Renamed Class to "Launch Workflow from EWS Account"
- Added settings to be able to change what messages are selected and how to mark them processed (i.e. flagged messages and remove flag, instead of the default Unread/Read)

**New Settings:**

- _Launch Workflows With_, What emails should this job use to launch workflows? Default: Unread (When multiple options are selected these are a combined search result, i.e Unread AND Flagged)
- _Mark Processed Emails by_, How should the emails be marked within EWS once they are processed. Default: Read (Note: not all options will work without appropriate permissions. Multiple options will perform all that it can in order presented.)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added settings to be able to change what messages are selected and how to mark them processed (i.e. flagged messages and remove flag, instead of the default Unread/Read)

---------

### Requested By

##### Who reported, requested, or paid for the change?

KFS

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/212187968-a2255772-c762-4b83-a4be-3a118ea57616.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.WorkflowFromEWS/Jobs/{StartWorkflow.cs → LaunchWorkflowFromEWSAccount.cs}
- rocks.kfs.WorkflowFromEWS/Properties/AssemblyInfo.cs
- rocks.kfs.WorkflowFromEWS/rocks.kfs.WorkflowFromEWS.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, job will need to be re-setup.
