### PR TITLE
Edify Possible Empty Email Fix #2

### DIFF
--- a/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
+++ b/rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs
@@ -99,18 +99,21 @@ namespace rocks.kfs.Edify.Communications.Transport
             }
 
             var toEmail = rockEmailMessage.GetRecipients();
-            toEmail.ForEach( r => toEmailList.Add( r.To ) );
+            toEmail
+                .Where( r => r.To.Trim() != string.Empty )
+                .ToList()
+                .ForEach( r => toEmailList.Add( r.To.Trim() ) );
 
             ccEmailList = rockEmailMessage
                 .CCEmails
-                .Where( cc => cc != string.Empty )
-                .Where( cc => !toEmail.Any( te => te.To == cc ) )
+                .Where( cc => cc.Trim() != string.Empty )
+                .Where( cc => !toEmailList.Contains( cc ) )
                 .ToList();
 
             bccEmailList = rockEmailMessage
                 .BCCEmails
-                .Where( bcc => bcc != string.Empty )
-                .Where( bcc => !toEmail.Any( te => te.To == bcc ) )
+                .Where( bcc => bcc.Trim() != string.Empty )
+                .Where( bcc => !toEmailList.Contains( bcc ) )
                 .Where( bcc => !ccEmailList.Contains( bcc ) )
                 .ToList();
 

--- a/rocks.kfs.Edify/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Edify/Properties/AssemblyInfo.cs
@@ -47,4 +47,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion( "1.4.*" )]
+[assembly: AssemblyVersion( "1.5.*" )]


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Pushing a fix for possible empty email address fix # 2. If CC or BCC is included an empty email address entry was still possible.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed a potential empty email address email still being allowed to be sent to Edify.

---------

### Requested By

##### Who reported, requested, or paid for the change?

College/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Edify/Communications/Transport/EdifyHTTP.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
