### PR TITLE
Simple Texting v13-14 Fix

### DIFF
--- a/rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj
+++ b/rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj
@@ -46,6 +46,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\Rock.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Common">
+      <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
+    </Reference>
     <Reference Include="SimpleTextingDotNet, Version=1.0.8354.33013, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SimpleTextingDotNet.1.0.8354.33013\lib\net452\SimpleTextingDotNet.dll</HintPath>
     </Reference>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Missing proper assembly reference to build Simple Texting for v13-14

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Missing proper assembly reference to build Simple Texting for v13-14

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
