### PR TITLE
Fundraising Participant Summary - Required Job Settings Fix

### DIFF
--- a/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
+++ b/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,10 +42,12 @@ namespace rocks.kfs.FundraisingParticipantSummary.Jobs
 
     [GroupTypesField( "Group Types",
         Description = "Use this setting to send the fundraising participant summary email to entire GroupType(s).",
+        IsRequired = false,
         Key = AttributeKey.GroupTypes )]
 
     [GroupField( "Group",
-        Description = "Use this setting to send the fundraising participant summary email to a specific Group and its child Groups.",
+        Description = "Use this setting to send the fundraising participant summary email to a specific Group and its child Groups. (If both settings are set, Group and its child groups will override Group Types).",
+        IsRequired = false,
         Key = AttributeKey.Group )]
 
     [BooleanField( "Show Address",
@@ -71,7 +73,7 @@ namespace rocks.kfs.FundraisingParticipantSummary.Jobs
     [IntegerField( "Command Timeout Override",
         Description = "Command Timeout value (in seconds) to use instead of default database connection timeout.",
         IsRequired = false,
-        Key = AttributeKey.CommandTimeoutOverride ) ]
+        Key = AttributeKey.CommandTimeoutOverride )]
     [DisallowConcurrentExecution]
     public class FundraisingParticipantSummary : IJob
     {
@@ -157,7 +159,7 @@ namespace rocks.kfs.FundraisingParticipantSummary.Jobs
 
                 var groupGuid = dataMap.GetString( AttributeKey.Group ).AsGuidOrNull();
 
-                if ( ( groupTypes.IsNull() || groupTypes.Count == 0 ) && !groupGuid.HasValue )
+                if ( ( groupTypes == null || groupTypes.Count == 0 ) && !groupGuid.HasValue )
                 {
                     context.Result = "Job failed. Unable to find group type or selected group. Check your settings.";
                     throw new Exception( "No group type found or group found." );

--- a/rocks.kfs.FundraisingParticipantSummary/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.FundraisingParticipantSummary/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.FundraisingParticipantSummary" )]
 [assembly: AssemblyProduct( "rocks.kfs.FundraisingParticipantSummary" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.3.*" )]
+[assembly: AssemblyVersion( "1.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix job settings that were not supposed to be required on Fundraising Participant summary. Prior to v13, job settings were not required by default, now they are and we need to be explicit when setting them.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Fix job settings that were not supposed to be required on Fundraising Participant summary

---------

### Requested By

##### Who reported, requested, or paid for the change?

Cedar Creek

---------

### Screenshots

##### Does this update or add options to the block UI?

No longer required as expected:   
![image](https://user-images.githubusercontent.com/2990519/230942442-dd6bf338-c9d6-47e2-b465-a7e4fe86405d.png)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
- rocks.kfs.FundraisingParticipantSummary/Properties/AssemblyInfo.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
