### PR TITLE
ShelbyFinancials - Add Cost Center Credit support

### DIFF
--- a/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
+++ b/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
@@ -1,0 +1,68 @@
+﻿// <copyright>
+// Copyright 2023 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+
+using Rock.Data;
+using Rock.Model;
+using Rock.Plugin;
+
+namespace rocks.kfs.ShelbyFinancials.Migrations
+{
+    [MigrationNumber( 3, "1.13.0" )]
+    public class AddCreditCostCenter : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // Relabel Cost Center attribute
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center Default/Debit", "Cost Center Default will be used on both Credit/Debit lines if Cost Center Credit does not contain a value, to preserve existing functionality.", 11, "", "CD925E61-F87D-461F-9EFA-C1E14397FC4D", "rocks.kfs.ShelbyFinancials.CostCenter" );
+
+            // New Cost Center Credit attribute
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center Credit", "", 12, "", "94D96FEB-73AD-4A07-9F03-257A988994D4", "rocks.kfs.ShelbyFinancials.CostCenterCredit" );
+
+            // set attribute category for new attribute
+
+            Sql( @"
+                    DECLARE @AccountCategoryId int = ( SELECT TOP 1 [Id] FROM [Category] WHERE [Guid] = 'F8893830-B331-4C9F-AA4C-470F0C9B0D18' )
+                    DECLARE @CostCenterCreditAttributeId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '94D96FEB-73AD-4A07-9F03-257A988994D4' )
+
+                    IF NOT EXISTS (
+                        SELECT *
+                        FROM [AttributeCategory]
+                        WHERE [AttributeId] = @CostCenterCreditAttributeId
+                        AND [CategoryId] = @AccountCategoryId )
+                    BEGIN
+                        INSERT INTO [AttributeCategory] ( [AttributeId], [CategoryId] )
+                        VALUES( @CostCenterCreditAttributeId, @AccountCategoryId )
+                    END
+                " );
+
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( "94D96FEB-73AD-4A07-9F03-257A988994D4" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center", "", 11, "", "CD925E61-F87D-461F-9EFA-C1E14397FC4D", "rocks.kfs.ShelbyFinancials.CostCenter" );
+        }
+    }
+}

--- a/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
+++ b/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
@@ -23,7 +23,7 @@ using Rock.Plugin;
 
 namespace rocks.kfs.ShelbyFinancials.Migrations
 {
-    [MigrationNumber( 3, "1.13.0" )]
+    [MigrationNumber( 3, "1.12.0" )]
     public class AddCreditCostCenter : Migration
     {
         /// <summary>

--- a/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
+++ b/rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
@@ -32,7 +32,7 @@ namespace rocks.kfs.ShelbyFinancials.Migrations
         public override void Up()
         {
             // Relabel Cost Center attribute
-            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center Default/Debit", "Cost Center Default will be used on both Credit/Debit lines if Cost Center Credit does not contain a value, to preserve existing functionality.", 11, "", "CD925E61-F87D-461F-9EFA-C1E14397FC4D", "rocks.kfs.ShelbyFinancials.CostCenter" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center Default/Debit", "Cost Center Default will be used on both Credit/Debit lines if Cost Center Credit does not contain a value.", 11, "", "CD925E61-F87D-461F-9EFA-C1E14397FC4D", "rocks.kfs.ShelbyFinancials.CostCenter" );
 
             // New Cost Center Credit attribute
             RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Cost Center Credit", "", 12, "", "94D96FEB-73AD-4A07-9F03-257A988994D4", "rocks.kfs.ShelbyFinancials.CostCenterCredit" );

--- a/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.4.*" )]
+[assembly: AssemblyVersion( "2.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.ShelbyFinancials/SFJournal.cs
+++ b/rocks.kfs.ShelbyFinancials/SFJournal.cs
@@ -176,7 +176,8 @@ namespace rocks.kfs.ShelbyFinancials
                     SuperFundNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.SuperFund" ),
                     FundNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.Fund" ),
                     LocationNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.Location" ),
-                    CostCenterNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.CostCenter" ),
+                    CostCenterDebitNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.CostCenter" ),
+                    CostCenterCreditNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.CostCenterCredit" ),
                     DepartmentNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.Department" ),
                     CreditAccountNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.CreditAccount" ),
                     DebitAccountNumber = account.GetAttributeValue( "rocks.kfs.ShelbyFinancials.DebitAccount" ),
@@ -213,7 +214,7 @@ namespace rocks.kfs.ShelbyFinancials
                     SuperFundNumber = transaction.SuperFundNumber,
                     FundNumber = transaction.FundNumber,
                     LocationNumber = transaction.LocationNumber,
-                    CostCenterNumber = transaction.CostCenterNumber,
+                    CostCenterNumber = transaction.CostCenterCreditNumber.IsNotNullOrWhiteSpace() ? transaction.CostCenterCreditNumber : transaction.CostCenterDebitNumber,
                     DepartmentNumber = transaction.DepartmentNumber,
                     AccountNumber = transaction.CreditAccountNumber,
                     AccountSub = transaction.RevenueAccountSub,
@@ -234,7 +235,7 @@ namespace rocks.kfs.ShelbyFinancials
                     SuperFundNumber = transaction.SuperFundNumber,
                     FundNumber = transaction.FundNumber,
                     LocationNumber = transaction.LocationNumber,
-                    CostCenterNumber = transaction.CostCenterNumber,
+                    CostCenterNumber = transaction.CostCenterDebitNumber,
                     DepartmentNumber = "0",
                     AccountNumber = transaction.DebitAccountNumber,
                     AccountSub = transaction.DebitAccountSub,
@@ -710,7 +711,8 @@ namespace rocks.kfs.ShelbyFinancials
             public string SuperFundNumber;
             public string FundNumber;
             public string LocationNumber;
-            public string CostCenterNumber;
+            public string CostCenterDebitNumber;
+            public string CostCenterCreditNumber;
             public string DepartmentNumber;
             public string CreditAccountNumber;
             public string DebitAccountNumber;

--- a/rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj
+++ b/rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Migrations\003_AddCreditCostCenter.cs" />
     <Compile Include="Migrations\002_AddDebitAccountSub.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added ability to configure specific cost center numbers for credits.

**Attributes:**

- Renamed existing "Cost Center" attribute to "Cost Center Default/Debit"
- Cost Center Credit: New attribute added to Financial Accounts in the Shelby Financials category to allow splitting the cost centers for deposits and credits. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Renamed existing "Cost Center" attribute to "Cost Center Default/Debit"
- Added Cost Center Credit attribute to financial accounts in the Shelby Financials category to allow splitting the cost centers for deposits and credits. 


---------

### Requested By

##### Who reported, requested, or paid for the change?

FPG

---------

### Screenshots

##### Does this update or add options to the block UI?

Attribute Changes:  
![image](https://user-images.githubusercontent.com/7374281/235522047-db9ae61e-d3e5-4f61-a094-906141710a64.png)

---------

### Change Log

##### What files does it affect?

* rocks.kfs.ShelbyFinancials/Migrations/003_AddCreditCostCenter.cs
* rocks.kfs.ShelbyFinancials/SFJournal.cs
* rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
