### PR TITLE
Better Intacct error handling

### DIFF
--- a/rocks.kfs.Intacct/IntacctEndpoint.cs
+++ b/rocks.kfs.Intacct/IntacctEndpoint.cs
@@ -112,49 +112,52 @@ namespace rocks.kfs.Intacct
 
         public bool ParseEndpointResponse( XmlDocument xmlDocument, int BatchId, bool Log = false )
         {
-            var resultX = XDocument.Load( new XmlNodeReader( xmlDocument ) );
-
-            if ( Log )
+            try
             {
-                var financialBatch = new FinancialBatchService( new RockContext() ).Get( BatchId );
-                var changes = new History.HistoryChangeList();
-                var oldValue = string.Empty;
-                var newValue = resultX.ToString();
+                var resultX = XDocument.Load( new XmlNodeReader( xmlDocument ) );
 
-                History.EvaluateChange( changes, "Intacct Response", oldValue, newValue );
-
-                var rockContext = new RockContext();
-                rockContext.WrapTransaction( () =>
+                if ( Log )
                 {
-                    if ( changes.Any() )
-                    {
-                        HistoryService.SaveChanges(
-                            rockContext,
-                            typeof( FinancialBatch ),
-                            Rock.SystemGuid.Category.HISTORY_FINANCIAL_BATCH.AsGuid(),
-                            BatchId,
-                            changes );
-                    }
-                } );
-            }
+                    var financialBatch = new FinancialBatchService( new RockContext() ).Get( BatchId );
+                    var changes = new History.HistoryChangeList();
+                    var oldValue = string.Empty;
+                    var newValue = resultX.ToString();
 
-            var xResponseXml = resultX.Elements( "response" ).FirstOrDefault();
-            if ( xResponseXml != null )
-            {
-                var xOperationXml = xResponseXml.Elements( "operation" ).FirstOrDefault();
-                if ( xOperationXml != null )
-                {
-                    var xResultXml = xOperationXml.Elements( "result" ).FirstOrDefault();
-                    if ( xResultXml != null )
+                    History.EvaluateChange( changes, "Intacct Response", oldValue, newValue );
+
+                    var rockContext = new RockContext();
+                    rockContext.WrapTransaction( () =>
                     {
-                        var xStatusXml = xResultXml.Elements( "status" ).FirstOrDefault();
-                        if ( xStatusXml != null && xStatusXml.Value == "success" )
+                        if ( changes.Any() )
                         {
-                            return true;
+                            HistoryService.SaveChanges(
+                                rockContext,
+                                typeof( FinancialBatch ),
+                                Rock.SystemGuid.Category.HISTORY_FINANCIAL_BATCH.AsGuid(),
+                                BatchId,
+                                changes );
+                        }
+                    } );
+                }
+
+                var xResponseXml = resultX.Elements( "response" ).FirstOrDefault();
+                if ( xResponseXml != null )
+                {
+                    var xOperationXml = xResponseXml.Elements( "operation" ).FirstOrDefault();
+                    if ( xOperationXml != null )
+                    {
+                        var xResultXml = xOperationXml.Elements( "result" ).FirstOrDefault();
+                        if ( xResultXml != null )
+                        {
+                            var xStatusXml = xResultXml.Elements( "status" ).FirstOrDefault();
+                            if ( xStatusXml != null && xStatusXml.Value == "success" )
+                            {
+                                return true;
+                            }
                         }
                     }
                 }
-            }
+            } catch ( Exception e ) { }
 
             return false;
         }

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.4.*" )]
+[assembly: AssemblyVersion( "2.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added error handling around parsing xml response

Requires https://github.com/KingdomFirst/RockBlocks/pull/139 to be useful

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added error handling around parsing xml response

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Intacct/IntacctEndpoint.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, just doesn't show any error at all without https://github.com/KingdomFirst/RockBlocks/pull/139
