### PR TITLE
Scheduled Group Communication SMS job v15 compatibility fix

### DIFF
--- a/rocks.kfs.Edify/rocks.kfs.Edify.csproj
+++ b/rocks.kfs.Edify/rocks.kfs.Edify.csproj
@@ -45,6 +45,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="UAParser, Version=3.1.44.0, Culture=neutral, PublicKeyToken=f7377bf021646069, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\UAParser.dll</HintPath>

--- a/rocks.kfs.GroupRoleAttendanceReminder/rocks.kfs.GroupRoleAttendanceReminder.csproj
+++ b/rocks.kfs.GroupRoleAttendanceReminder/rocks.kfs.GroupRoleAttendanceReminder.csproj
@@ -68,6 +68,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="Rock.Rest">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\Rock.Rest.dll</HintPath>

--- a/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
+++ b/rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
@@ -48,6 +48,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>

--- a/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
+++ b/rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
@@ -45,6 +45,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="UAParser, Version=3.1.44.0, Culture=neutral, PublicKeyToken=f7377bf021646069, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\RockWeb\Bin\UAParser.dll</HintPath>

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -73,7 +73,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
             var smsMediumType = EntityTypeCache.Get( "Rock.Communication.Medium.Sms" );
             var dateAttributeId = Rock.Web.Cache.AttributeCache.Get( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_DATE.AsGuid() ).Id;
             var recurrenceAttributeId = Rock.Web.Cache.AttributeCache.Get( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE.AsGuid() ).Id;
-            var fromNumberAttributeId = Rock.Web.Cache.AttributeCache.Get( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER.AsGuid() ).Id;
+            var fromNumberAttributeId = Rock.Web.Cache.AttributeCache.Get( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE.AsGuid() ).Id;
             var messageAttributeId = Rock.Web.Cache.AttributeCache.Get( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_MESSAGE.AsGuid() ).Id;
 
             try
@@ -141,7 +141,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                         var fromNumberGuid = new AttributeValueService( rockContext )
                             .GetByAttributeIdAndEntityId( fromNumberAttributeId, attributeMatrixItemAndGroupId.Key )
                             .Value;
-                        var fromNumber = DefinedValueCache.Get( fromNumberGuid.AsGuid() );
+                        var fromNumber = SystemPhoneNumberCache.Get( fromNumberGuid.AsGuid() );
 
                         var message = new AttributeValueService( rockContext )
                             .GetByAttributeIdAndEntityId( messageAttributeId, attributeMatrixItemAndGroupId.Key )
@@ -207,7 +207,7 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                 }
 
                                 communication.SMSMessage = message;
-                                communication.SMSFromDefinedValueId = fromNumber.Id;
+                                communication.SmsFromSystemPhoneNumberId = fromNumber.Id;
                                 communication.Subject = string.Empty;
                                 communication.Status = CommunicationStatus.Approved;
 

--- a/rocks.kfs.ScheduledGroupCommunication/Migrations/004_SystemPhoneSupport.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Migrations/004_SystemPhoneSupport.cs
@@ -1,0 +1,91 @@
+﻿// <copyright>
+// Copyright 2019 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.ScheduledGroupCommunication.SystemGuid;
+
+namespace rocks.kfs.ScheduledGroupCommunication.Migrations
+{
+    [MigrationNumber( 4, "1.15.0" )]
+    internal class SystemPhoneSupport : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            var rockContextSMS = new RockContext();
+
+            var attributeMatrixTemplateSMSId = new AttributeMatrixTemplateService( rockContextSMS ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS.AsGuid() ).Id.ToString();
+
+            // Add new from number attribute to existing matrix
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.SYSTEM_PHONE_NUMBER, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "From Number", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE, "rocks.kfs.ScheduledGroupCommunication.SMSFromNumberSystemPhone" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE, "allowMultiple", "False", "E519CA4D-2E4E-4265-9DCD-2010647748AF" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE, "includeInactive", "False", "03B877A1-4822-4210-B739-8A83B747BE49" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE, "repeatColumns", "", "CA8E4252-E94C-4631-9705-8F1E33B8E215" );
+
+            // set new attribute to be required
+            Sql( string.Format( @"
+            UPDATE [Attribute] SET [IsRequired] = 1
+            WHERE [Guid] = '{0}'", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE ) );
+
+            // Migrate existing attribute values to new attribute
+            Sql( string.Format( @"
+            DECLARE @OldSMSFromNumberAttributeId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{0}' )
+            DECLARE @NewSMSFromNumberAttributeId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{1}' )
+            UPDATE [AttributeValue] SET [AttributeId] = @NewSMSFromNumberAttributeId
+            WHERE [AttributeId] = @OldSMSFromNumberAttributeId", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE ) );
+
+            // Remove old From Number attribute
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER );
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            // Add back original From Number
+            var rockContextSMS = new RockContext();
+            var attributeMatrixTemplateSMSId = new AttributeMatrixTemplateService( rockContextSMS ).Get( KFSConst.Attribute.ATTRIBUTE_MATRIX_TEMPLATE_SCHEDULED_SMS.AsGuid() ).Id.ToString();
+
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", Rock.SystemGuid.FieldType.DEFINED_VALUE, "AttributeMatrixTemplateId", attributeMatrixTemplateSMSId, "From Number", "", 1, "", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "rocks.kfs.ScheduledGroupCommunication.SMSFromNumber" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "allowmultiple", "False", "90051033-C881-42E8-A0CE-4152527D6FA3" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "definedtype", "", "26143779-5747-416C-98B9-EBC86E4B8EE6" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "displaydescription", "True", "8AABC104-CFE5-4DF1-A164-2DA305F46BBC" );
+            RockMigrationHelper.AddAttributeQualifier( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, "enhancedselection", "False", "B0008343-0033-4194-A1A8-F5AEF3B095AD" );
+            Sql( @"
+            DECLARE @CommunicationSMSFromDefinedTypeId int = ( SELECT TOP 1 [Id] FROM [DefinedType] WHERE [Guid] = '611BDE1F-7405-4D16-8626-CCFEDB0E62BE' )
+            UPDATE [AttributeQualifier] SET [Value] = CAST( @CommunicationSMSFromDefinedTypeId AS varchar )
+            WHERE [Guid] = '26143779-5747-416C-98B9-EBC86E4B8EE6'" );
+
+            // Reverse attribute value migration
+            Sql( string.Format( @"
+            DECLARE @OldSMSFromNumberAttributeId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{0}' )
+            DECLARE @NewSMSFromNumberAttributeId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{1}' )
+            UPDATE [AttributeValue] SET [AttributeId] = @OldSMSFromNumberAttributeId
+            WHERE [AttributeId] = @NewSMSFromNumberAttributeId", KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER, KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE ) );
+
+            // Delete attribute
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE );
+        }
+    }
+}

--- a/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.ScheduledGroupCommunication" )]
 [assembly: AssemblyProduct( "rocks.kfs.ScheduledGroupCommunication" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.8.*" )]
+[assembly: AssemblyVersion( "2.0.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
@@ -78,9 +78,14 @@ namespace rocks.kfs.ScheduledGroupCommunication.SystemGuid
         public const string MATRIX_ATTRIBUTE_SMS_SEND_RECURRENCE = "EC6D13F7-A256-4B03-A94B-3B713F26E62D";
 
         /// <summary>
-        /// The matrix attribute for SMS from address
+        /// The matrix attribute for SMS from phone number
         /// </summary>
         public const string MATRIX_ATTRIBUTE_SMS_FROM_NUMBER = "1984A561-C4A9-4D4F-B366-23AD54BDCFE8";
+
+        /// <summary>
+        /// The matrix attribute for SMS from System Phone Number
+        /// </summary>
+        public const string MATRIX_ATTRIBUTE_SMS_FROM_NUMBER_SYSTEM_PHONE = "A97CA985-53F5-4C0C-8827-FBB0B082162E";
 
         /// <summary>
         /// The matrix attribute for SMS message

--- a/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
+++ b/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <Compile Include="Jobs\SendScheduledGroupEmail.cs" />
     <Compile Include="Jobs\SendScheduledGroupSMS.cs" />
+    <Compile Include="Migrations\004_SystemPhoneSupport.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />
     <Compile Include="Migrations\003_AddDailyRecurrence.cs" />
     <Compile Include="Migrations\002_AddRecurrenceAttribute.cs" />

--- a/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
+++ b/rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />

--- a/rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj
+++ b/rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj
@@ -49,6 +49,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="SimpleTextingDotNet, Version=1.0.8354.33013, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SimpleTextingDotNet.1.0.8354.33013\lib\net452\SimpleTextingDotNet.dll</HintPath>
     </Reference>

--- a/rocks.kfs.Workflow.Action.Cms/rocks.kfs.Workflow.Action.Cms.csproj
+++ b/rocks.kfs.Workflow.Action.Cms/rocks.kfs.Workflow.Action.Cms.csproj
@@ -50,6 +50,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="Rock.Lava.Shared">
       <HintPath>..\..\RockWeb\Bin\Rock.Lava.Shared.dll</HintPath>
     </Reference>

--- a/rocks.kfs.Workflow.Action.Core/rocks.kfs.Workflow.Action.Core.csproj
+++ b/rocks.kfs.Workflow.Action.Core/rocks.kfs.Workflow.Action.Core.csproj
@@ -42,6 +42,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/rocks.kfs.Zoom/rocks.kfs.Zoom.csproj
+++ b/rocks.kfs.Zoom/rocks.kfs.Zoom.csproj
@@ -79,6 +79,9 @@
     <Reference Include="Rock.Common">
       <HintPath>..\..\RockWeb\Bin\Rock.Common.dll</HintPath>
     </Reference>
+    <Reference Include="Rock.Enums">
+      <HintPath>..\..\RockWeb\Bin\Rock.Enums.dll</HintPath>
+    </Reference>
     <Reference Include="Rock.Lava.Shared">
       <HintPath>..\..\RockWeb\Bin\Rock.Lava.Shared.dll</HintPath>
     </Reference>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

In version 15 of Rock RMS, a structural change for managing SMS phone numbers was made. They have transitioned from using Defined Values within a special Defined Type to a new entity, System Phone Number. This change was propagated into how the "From Number" is populated for SMS communications. The changes in this version of our plugin are required to make it compatible with Rock v15 and above. Consequently, these changes will make this version of KFS's SendScheduledGroupSMS job incompatible with any Rock versions previous to v15 due to the significant change to the Rock model. As such, the version of this plugin was moved to 2.0.

Also in this merge are several other plugin fixes needing references to the new Rock.Enums dll.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Updated SMS Communication "From Number" logic to work with v15 model changes.  
* Updated remaining plugins to properly reference the new Rock.Enums dll.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* rocks.kfs.Edify/rocks.kfs.Edify.csproj
* rocks.kfs.GroupRoleAttendanceReminder/rocks.kfs.GroupRoleAttendanceReminder.csproj
* rocks.kfs.GroupRoundRobinAssignment/rocks.kfs.GroupRoundRobinAssignment.csproj
* rocks.kfs.PostalServer/rocks.kfs.PostalServer.csproj
* rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
* rocks.kfs.ScheduledGroupCommunication/Migrations/004_SystemPhoneSupport.cs
* rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
* rocks.kfs.ScheduledGroupCommunication/SystemGuid/Attribute.cs
* rocks.kfs.ScheduledGroupCommunication/rocks.kfs.ScheduledGroupCommunication.csproj
* rocks.kfs.SimpleTexting/rocks.kfs.SimpleTexting.csproj
* rocks.kfs.Workflow.Action.Cms/rocks.kfs.Workflow.Action.Cms.csproj
* rocks.kfs.Workflow.Action.Core/rocks.kfs.Workflow.Action.Core.csproj
* rocks.kfs.Zoom/rocks.kfs.Zoom.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes. This update makes KFS's SendScheduledGroupSMS job only compatible with Rock v15 and higher
