### PR TITLE
Fundraising Participant Summary Bug fix

### DIFF
--- a/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
+++ b/rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs
@@ -177,7 +177,7 @@ namespace rocks.kfs.FundraisingParticipantSummary.Jobs
                 }
                 else
                 {
-                    LogEvent( null, "GroupInfo", string.Format( "Selected Group: {0}", groupGuid.Value ), "Get Groups from group type setting.", enableLogging );
+                    LogEvent( null, "GroupInfo", string.Format( "Selected GroupTypes Count: {0}", groupTypes.Count ), "Get Groups from group type setting.", enableLogging );
                     groups = groupService.Queryable( "Members" ).AsNoTracking().Where( g => groupTypes.Contains( g.GroupTypeId ) ).ToList();
                     LogEvent( null, "GroupInfo", string.Format( "Groups: {0}", groups.Count() ), "Finished getting Groups from group type setting.", enableLogging );
                 }

--- a/rocks.kfs.FundraisingParticipantSummary/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.FundraisingParticipantSummary/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.4.*" )]
+[assembly: AssemblyVersion( "1.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for "Nullable object must have a value." exception when using just using Group Type.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fix for "Nullable object must have a value." exception when using just using Group Type.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.FundraisingParticipantSummary/Jobs/FundraisingParticipantSummary.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No