### PR TITLE
Group Round Robin Assignment Changes

### DIFF
--- a/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
+++ b/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
+++ b/rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs
@@ -104,8 +104,8 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
 
     [BooleanField(
         "Use Group Campus",
-        Description = "Should the job use Group Campus to match groups to person campus when assigning people to groups? Default: Yes",
-        DefaultBooleanValue = true,
+        Description = "Should the job use Group Campus to match groups to person campus when assigning people to groups? Default: No",
+        DefaultBooleanValue = false,
         Key = AttributeKey.UseGroupCampus )]
 
     [BooleanField(

--- a/rocks.kfs.GroupRoundRobinAssignment/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.GroupRoundRobinAssignment/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.GroupRoundRobinAssignment" )]
 [assembly: AssemblyProduct( "rocks.kfs.GroupRoundRobinAssignment" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION

### Description 

##### What does the change add or fix?

Added additional settings for disabling campus requirement, removing group members and outputting errors to job history. Also fixed an issue that wouldn't check for family members in existing groups when being added. (Fixes #116)

**New Settings:**

- **Output Errors to History**, Should the job output all errors to job history? Default: Yes
- **Remove Members not in Data View**, Should the job automatically remove group members not in the Data View? (Note: if you 'Include Family Members' your Data View should include them to prevent them from being removed with this setting.) Default: No
- **Use Group Campus**, Should the job use Group Campus to match groups to person campus when assigning people to groups? Default: Yes

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added additional settings for disabling campus requirement, removing group members and outputting errors to job history. 
- Fixed an issue that wouldn't check for family members in existing groups when being added. (Fixes #116)

---------

### Requested By

##### Who reported, requested, or paid for the change?

College

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/KingdomFirst/RockAssemblies/assets/2990519/c4da3eb4-ec2d-42bc-9548-86d3aa9441e5)

---------

### Change Log

##### What files does it affect?

rocks.kfs.GroupRoundRobinAssignment/Jobs/GroupRoundRobinAssignment.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
