### PR TITLE
F: BatchToIntacct - Add support for debit specific attributes

### DIFF
--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -220,7 +220,7 @@ namespace rocks.kfs.Intacct
             foreach ( var summary in batchTransactionsSummary )
             {
                 var account = new FinancialAccountService( rockContext ).Get( summary.FinancialAccountId );
-                var customDimensionValues = new Dictionary<string, dynamic>();
+                var customDimensionValues = new SortedDictionary<string, dynamic>();
                 account.LoadAttributes();
                 var mergeFieldObjects = new MergeFieldObjects
                 {
@@ -306,7 +306,7 @@ namespace rocks.kfs.Intacct
                     .ToList();
 
                 feeDebitTransactions = feeDebitTransactions
-                    .GroupBy( d => new { d.DebitClass, d.DebitDepartment, d.DebitLocation, d.DebitProject, d.CustomDimensionString, d.DebitAccount } )
+                    .GroupBy( d => new { d.DebitClass, d.DebitDepartment, d.DebitLocation, d.DebitProject, d.DebitAccount, d.CustomDimensionString } )
                     .Select( s => new GLBatchTotals
                     {
                         Amount = s.Sum( f => f.Amount ),

--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -299,14 +299,14 @@ namespace rocks.kfs.Intacct
                         DebitClass = s.Key.DebitClass,
                         DebitDepartment = s.Key.DebitDepartment,
                         DebitLocation = s.Key.DebitLocation,
-                        CreditProject = s.Key.DebitProject,
+                        DebitProject = s.Key.DebitProject,
                         Description = s.First().Description,
                         CustomDimensions = s.First().CustomDimensions
                     } )
                     .ToList();
 
                 feeDebitTransactions = feeDebitTransactions
-                    .GroupBy( d => new { d.DebitClass, d.DebitDepartment, d.DebitLocation, d.DebitProject, d.DebitAccount } )
+                    .GroupBy( d => new { d.DebitClass, d.DebitDepartment, d.DebitLocation, d.DebitProject, d.CustomDimensionString, d.DebitAccount } )
                     .Select( s => new GLBatchTotals
                     {
                         Amount = s.Sum( f => f.Amount ),
@@ -359,7 +359,7 @@ namespace rocks.kfs.Intacct
                     .ToList();
 
                 feeCreditTransactions = feeCreditTransactions
-                    .GroupBy( d => new { d.CreditClass, d.CreditDepartment, d.CreditLocation, d.CreditProject, d.CreditAccount } )
+                    .GroupBy( d => new { d.CreditClass, d.CreditDepartment, d.CreditLocation, d.CreditProject, d.CreditAccount, d.CustomDimensionString } )
                     .Select( s => new GLBatchTotals
                     {
                         Amount = s.Sum( f => f.Amount ),

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -59,7 +59,7 @@ namespace rocks.kfs.Intacct
         public string ContractId;
         public string WarehouseId;
         public List<AllocationLine> CustomAllocationSplits = new List<AllocationLine>();
-        public Dictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
+        public SortedDictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
     }
 
     public class AllocationLine
@@ -253,7 +253,8 @@ namespace rocks.kfs.Intacct
         public string DebitLocation;
         public string DebitProject;
         public string Description;
-        public Dictionary<string, dynamic> CustomDimensions;
+        public SortedDictionary<string, dynamic> CustomDimensions;
+        public string CustomDimensionString;
         public int ProcessTransactionFees;
 
         public object Clone()

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -129,7 +129,10 @@ namespace rocks.kfs.Intacct
         public int FinancialAccountId;
 
         [LavaInclude]
-        public string Project;
+        public string CreditProject;
+
+        [LavaInclude]
+        public string DebitProject;
 
         [LavaInclude]
         public decimal TransactionFeeAmount;
@@ -241,10 +244,14 @@ namespace rocks.kfs.Intacct
         public string DebitAccount;
         public string TransactionFeeAccount;
         public decimal TransactionFeeAmount;
-        public string Class;
-        public string Department;
-        public string Location;
-        public string Project;
+        public string CreditClass;
+        public string CreditDepartment;
+        public string CreditLocation;
+        public string CreditProject;
+        public string DebitClass;
+        public string DebitDepartment;
+        public string DebitLocation;
+        public string DebitProject;
         public string Description;
         public Dictionary<string, dynamic> CustomDimensions;
         public int ProcessTransactionFees;

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -108,7 +108,8 @@ namespace rocks.kfs.Intacct
         public string Memo;
         public string LocationId;
         public string DepartmentId;
-        public Dictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
+        public SortedDictionary<string, dynamic> CustomFields = new SortedDictionary<string, object>();
+        public string CustomFieldsString;
         public string ProjectId;
         public string TaskId;
         public string CostTypeId;

--- a/rocks.kfs.Intacct/IntacctModels.cs
+++ b/rocks.kfs.Intacct/IntacctModels.cs
@@ -59,7 +59,7 @@ namespace rocks.kfs.Intacct
         public string ContractId;
         public string WarehouseId;
         public List<AllocationLine> CustomAllocationSplits = new List<AllocationLine>();
-        public SortedDictionary<string, dynamic> CustomFields = new Dictionary<string, object>();
+        public SortedDictionary<string, dynamic> CustomFields = new SortedDictionary<string, object>();
     }
 
     public class AllocationLine

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -171,13 +171,21 @@ namespace rocks.kfs.Intacct
                             {
                                 writer.WriteElementString( "classid", item.ClassId );
                             }
-                            if ( item.CustomFields.Count > 0 )
-                            {
-                                foreach ( KeyValuePair<string, dynamic> customField in item.CustomFields )
-                                {
-                                    writer.WriteElementString( customField.Key, customField.Value ?? string.Empty );
-                                }
-                            }
+
+                            // Intacct api documentation shows legacy support for custom fields, but we are unable to get them to work. Disabling for now.
+
+                            //if ( item.CustomFields.Count > 0 )
+                            //{
+                            //    writer.WriteStartElement( "customfields" );
+                            //    foreach ( KeyValuePair<string, dynamic> customField in item.CustomFields )
+                            //    {
+                            //        writer.WriteStartElement( "customfield" );
+                            //        writer.WriteElementString( "customfieldname", customField.Key );
+                            //        writer.WriteElementString( "customfieldvalue", customField.Value ?? string.Empty );
+                            //        writer.WriteEndElement();  // close customfield
+                            //    }
+                            //    writer.WriteEndElement();  // close customfields
+                            //}
                             writer.WriteEndElement();  // close lineitem
                         }
 

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -172,19 +172,14 @@ namespace rocks.kfs.Intacct
                                 writer.WriteElementString( "classid", item.ClassId );
                             }
 
-                            // Intacct api documentation shows legacy support for custom fields, but we are unable to get them to work. Disabling for now.
+                            // Intacct api documentation shows support for custom fields, but we are unable to get them to work. Disabling for now.
 
                             //if ( item.CustomFields.Count > 0 )
                             //{
-                            //    writer.WriteStartElement( "customfields" );
                             //    foreach ( KeyValuePair<string, dynamic> customField in item.CustomFields )
                             //    {
-                            //        writer.WriteStartElement( "customfield" );
-                            //        writer.WriteElementString( "customfieldname", customField.Key );
-                            //        writer.WriteElementString( "customfieldvalue", customField.Value ?? string.Empty );
-                            //        writer.WriteEndElement();  // close customfield
+                            //        writer.WriteElementString( customField.Key, customField.Value ?? string.Empty );
                             //    }
-                            //    writer.WriteEndElement();  // close customfields
                             //}
                             writer.WriteEndElement();  // close lineitem
                         }

--- a/rocks.kfs.Intacct/IntacctOtherReceipt.cs
+++ b/rocks.kfs.Intacct/IntacctOtherReceipt.cs
@@ -264,7 +264,7 @@ namespace rocks.kfs.Intacct
                     Memo = DescriptionLava.ResolveMergeFields( mergeFields ),
                     LocationId = locationId,
                     DepartmentId = departmentId,
-                    ProjectId = bTran.Project,
+                    ProjectId = bTran.CreditProject,
                     ClassId = classId,
                     CustomFields = customDimensionValues
                 };
@@ -279,7 +279,7 @@ namespace rocks.kfs.Intacct
                         Memo = "Transaction Fees",
                         LocationId = locationId,
                         DepartmentId = departmentId,
-                        ProjectId = bTran.Project,
+                        ProjectId = bTran.CreditProject,
                         ClassId = classId
                     };
                     lineItemList.Add( feeLineItem );

--- a/rocks.kfs.Intacct/Migrations/001_AddSystemData.cs
+++ b/rocks.kfs.Intacct/Migrations/001_AddSystemData.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.Intacct/Migrations/002_AddTransactionFeeAttributes.cs
+++ b/rocks.kfs.Intacct/Migrations/002_AddTransactionFeeAttributes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.Intacct/Migrations/003_AddBatchesToIntacct.cs
+++ b/rocks.kfs.Intacct/Migrations/003_AddBatchesToIntacct.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.Intacct/Migrations/004_AddDebitAccountAttributes.cs
+++ b/rocks.kfs.Intacct/Migrations/004_AddDebitAccountAttributes.cs
@@ -1,0 +1,264 @@
+﻿// <copyright>
+// Copyright 2023 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//9DF341B7-2E07-44BA-94B1-F637BE551961
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.Intacct.SystemGuid;
+
+namespace rocks.kfs.Intacct.Migrations
+{
+    [MigrationNumber( 4, "1.11.0" )]
+    public class AddDebitAccountAttributes : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // ADD NEW DEBIT ACCOUNT ATTRIBUTES FOR FINANCIAL ACCOUNTS
+            // project
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.DEFINED_VALUE, "", "", "Default Debit Project", "Designates the Project for the assigned Debit Account at the Financial Account Level.", 6, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, "rocks.kfs.Intacct.DEBITPROJECTID" );
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, "allowmultiple", "False", "4A597C2F-034F-4855-B939-F44EA19B4194" );
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, "definedtype", "", "07C034DB-AD00-4BB9-A0B0-3BC35BF7A994" );
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, "displaydescription", "True", "B87B2631-5692-4346-BDD7-557FC224FF40" );
+            RockMigrationHelper.UpdateAttributeQualifier( KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, "enhancedselection", "True", "88B9BF14-0756-45B1-9B7F-5BFE1A4DDF7D" );
+
+            // set defined type qualifiers
+            Sql( @"
+                DECLARE @ProjectDefinedTypeId int = ( SELECT TOP 1 [Id] FROM [DefinedType] WHERE [Guid] = 'C244D4C4-636F-4BCA-8E7C-1907933ABB74' )
+
+                UPDATE [AttributeQualifier] SET [Value] = CAST( @ProjectDefinedTypeId AS varchar )
+                WHERE [Guid] = '07C034DB-AD00-4BB9-A0B0-3BC35BF7A994'
+            " );
+
+            // gl attributes
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Debit Class", "The Intacct dimension for Class Id to be used for assigned Debit Account.", 7, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS_DEBIT, "rocks.kfs.Intacct.DEBITCLASSID" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Debit Department", "The Intacct dimension for Department Id to be used for assigned Debit Account.", 8, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT_DEBIT, "rocks.kfs.Intacct.DEBITDEPARTMENT" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Debit Location", "The Intacct dimension for Location Id to be used for assigned Debit Account. Required if multi-entity enabled.", 9, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION_DEBIT, "rocks.kfs.Intacct.DEBITLOCATION" );
+
+            // set attribute category for new attributes
+            Sql( string.Format( @"
+                --
+                -- Set FinancialAccount attributes to category
+                --
+
+                DECLARE @AccountCategoryId int = ( SELECT TOP 1 [Id] FROM [Category] WHERE [Guid] = '{0}' )
+                DECLARE @AccountDefaultProject int = ( SELECT [Id] FROM [Attribute] WHERE [Guid] = '{1}' )
+
+                IF NOT EXISTS ( SELECT [AttributeId], [CategoryId] FROM [AttributeCategory] WHERE [AttributeId] = @AccountDefaultProject AND [CategoryId] = @AccountCategoryId )
+
+                BEGIN
+                    INSERT INTO [AttributeCategory]
+                    SELECT @AccountDefaultProject, @AccountCategoryId
+                END
+
+                DECLARE @AccountDebitClass int = ( SELECT [Id] FROM [Attribute] WHERE [Guid] = '{2}' )
+
+                IF NOT EXISTS ( SELECT [AttributeId], [CategoryId] FROM [AttributeCategory] WHERE [AttributeId] = @AccountDebitClass AND [CategoryId] = @AccountCategoryId )
+
+                BEGIN
+                    INSERT INTO [AttributeCategory]
+                    SELECT @AccountDebitClass, @AccountCategoryId
+                END
+
+                DECLARE @AccountDebitDepartment int = ( SELECT [Id] FROM [Attribute] WHERE [Guid] = '{3}' )
+
+                IF NOT EXISTS ( SELECT [AttributeId], [CategoryId] FROM [AttributeCategory] WHERE [AttributeId] = @AccountDebitDepartment AND [CategoryId] = @AccountCategoryId )
+
+                BEGIN
+                    INSERT INTO [AttributeCategory]
+                    SELECT @AccountDebitDepartment, @AccountCategoryId
+                END
+
+                DECLARE @AccountDebitLocation int = ( SELECT [Id] FROM [Attribute] WHERE [Guid] = '{4}' )
+
+                IF NOT EXISTS ( SELECT [AttributeId], [CategoryId] FROM [AttributeCategory] WHERE [AttributeId] = @AccountDebitLocation AND [CategoryId] = @AccountCategoryId )
+
+                BEGIN
+                    INSERT INTO [AttributeCategory]
+                    SELECT @AccountDebitLocation, @AccountCategoryId
+                END
+            ", KFSConst.Attribute.FINANCIAL_ACCOUNT_ATTRIBUTE_CATEGORY, KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION_DEBIT ) );
+
+            // rename and reorder of existing attributes
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.DEFINED_VALUE, "", "", "Default Credit Project", "Designates the Project for the assigned Credit Account at the Financial Account Level.", 1, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT, "rocks.kfs.Intacct.PROJECTID" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Credit Class", "The Intacct dimension for Class Id to be used for assigned Credit Account.", 2, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS, "rocks.kfs.Intacct.CLASSID" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Credit Department", "The Intacct dimension for Department Id to be used for assigned Credit Account.", 3, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT, "rocks.kfs.Intacct.DEPARTMENT" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Credit Location", "The Intacct dimension for Location Id to be used for assigned Credit Account. Required if multi-entity enabled.", 4, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION, "rocks.kfs.Intacct.LOCATION" );
+
+            // reorder remaining attributes
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Credit Account", "Account number to use for credit column. Required by Intacct.", 0, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_CREDIT_ACCOUNT, "rocks.kfs.Intacct.ACCOUNTNO" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Debit Account", "Account number to use for debit column. Required by Intacct.", 5, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_DEBIT_ACCOUNT, "rocks.kfs.Intacct.DEBITACCOUNTNO" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Transaction Fee Account", "Expense account number for gateway transaction fees.", 10, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_FEE_ACCOUNT, "rocks.kfs.Intacct.FEEACCOUNTNO" );
+
+            // copy values already provided in existing (now credit) attributes into corresponding new debit attributes to keep previous functionality in tact
+            Sql( string.Format( @"
+                --
+                -- Default Project
+                --
+
+                DECLARE @CreditProjectAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{0}' )
+                DECLARE @DebitProjectAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{1}' )
+
+                INSERT INTO [AttributeValue]
+                   ([IsSystem]
+                   ,[AttributeId]
+                   ,[EntityId]
+                   ,[Value]
+                   ,[Guid]
+                   ,[CreatedDateTime]
+                   ,[ModifiedDateTime]
+                   ,[CreatedByPersonAliasId]
+                   ,[ModifiedByPersonAliasId]
+                   ,[ValueAsNumeric])
+
+                SELECT AV.[IsSystem], 
+                    @DebitProjectAttrId, 
+                    AV.[EntityId], 
+                    AV.[Value],
+                    NEWID(), 
+                    AV.[CreatedDateTime], 
+                    AV.[ModifiedDateTime], 
+                    AV.[CreatedByPersonAliasId],
+                    AV.[ModifiedByPersonAliasId],
+                    AV.[ValueAsNumeric]
+                FROM AttributeValue AV WITH(NOLOCK)
+                LEFT JOIN AttributeValue AV2 WITH(NOLOCK) ON AV.EntityId = AV2.EntityId AND AV2.AttributeId = @DebitProjectAttrId 
+                WHERE AV.AttributeId = @CreditProjectAttrId AND AV2.Id IS NULL;
+
+                --
+                -- Class
+                --
+
+                DECLARE @CreditClassAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{2}' )
+                DECLARE @DebitClassAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{3}' )
+
+                INSERT INTO [AttributeValue]
+                   ([IsSystem]
+                   ,[AttributeId]
+                   ,[EntityId]
+                   ,[Value]
+                   ,[Guid]
+                   ,[CreatedDateTime]
+                   ,[ModifiedDateTime]
+                   ,[CreatedByPersonAliasId]
+                   ,[ModifiedByPersonAliasId]
+                   ,[ValueAsNumeric])
+
+                SELECT AV.[IsSystem], 
+                    @DebitClassAttrId, 
+                    AV.[EntityId], 
+                    AV.[Value],
+                    NEWID(), 
+                    AV.[CreatedDateTime], 
+                    AV.[ModifiedDateTime], 
+                    AV.[CreatedByPersonAliasId],
+                    AV.[ModifiedByPersonAliasId],
+                    AV.[ValueAsNumeric]
+                FROM AttributeValue AV WITH(NOLOCK)
+                LEFT JOIN AttributeValue AV2 WITH(NOLOCK) ON AV.EntityId = AV2.EntityId AND AV2.AttributeId = @DebitClassAttrId 
+                WHERE AV.AttributeId = @CreditClassAttrId AND AV2.Id IS NULL;
+
+                --
+                -- Department
+                --
+
+                DECLARE @CreditDepartmentAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{4}' )
+                DECLARE @DebitDepartmentAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{5}' )
+
+                INSERT INTO [AttributeValue]
+                   ([IsSystem]
+                   ,[AttributeId]
+                   ,[EntityId]
+                   ,[Value]
+                   ,[Guid]
+                   ,[CreatedDateTime]
+                   ,[ModifiedDateTime]
+                   ,[CreatedByPersonAliasId]
+                   ,[ModifiedByPersonAliasId]
+                   ,[ValueAsNumeric])
+
+                SELECT AV.[IsSystem], 
+                    @DebitDepartmentAttrId, 
+                    AV.[EntityId], 
+                    AV.[Value],
+                    NEWID(), 
+                    AV.[CreatedDateTime], 
+                    AV.[ModifiedDateTime], 
+                    AV.[CreatedByPersonAliasId],
+                    AV.[ModifiedByPersonAliasId],
+                    AV.[ValueAsNumeric]
+                FROM AttributeValue AV WITH(NOLOCK)
+                LEFT JOIN AttributeValue AV2 WITH(NOLOCK) ON AV.EntityId = AV2.EntityId AND AV2.AttributeId = @DebitDepartmentAttrId 
+                WHERE AV.AttributeId = @CreditDepartmentAttrId AND AV2.Id IS NULL;
+
+                --
+                -- Location
+                --
+
+                DECLARE @CreditLocationAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{6}' )
+                DECLARE @DebitLocationAttrId int = ( SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '{7}' )
+
+                INSERT INTO [AttributeValue]
+                   ([IsSystem]
+                   ,[AttributeId]
+                   ,[EntityId]
+                   ,[Value]
+                   ,[Guid]
+                   ,[CreatedDateTime]
+                   ,[ModifiedDateTime]
+                   ,[CreatedByPersonAliasId]
+                   ,[ModifiedByPersonAliasId]
+                   ,[ValueAsNumeric])
+
+                SELECT AV.[IsSystem], 
+                    @DebitLocationAttrId, 
+                    AV.[EntityId], 
+                    AV.[Value],
+                    NEWID(), 
+                    AV.[CreatedDateTime], 
+                    AV.[ModifiedDateTime], 
+                    AV.[CreatedByPersonAliasId],
+                    AV.[ModifiedByPersonAliasId],
+                    AV.[ValueAsNumeric]
+                FROM AttributeValue AV WITH(NOLOCK)
+                LEFT JOIN AttributeValue AV2 WITH(NOLOCK) ON AV.EntityId = AV2.EntityId AND AV2.AttributeId = @DebitLocationAttrId 
+                WHERE AV.AttributeId = @CreditLocationAttrId AND AV2.Id IS NULL;
+            ", KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT, KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS, KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT, KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT_DEBIT, KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION, KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION_DEBIT ) );
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            // remove debit account related attributes
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT_DEBIT );
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS_DEBIT );
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT_DEBIT );
+            RockMigrationHelper.DeleteAttribute( KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION_DEBIT );
+
+            // update name and order of original attributes 
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.DEFINED_VALUE, "", "", "Default Project", "Designates the Project at the Financial Account Level", 0, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_PROJECT, "rocks.kfs.Intacct.PROJECTID" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Class", "The Intacct dimension for Class Id.", 4, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_CLASS, "rocks.kfs.Intacct.CLASSID" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Department", "The Intacct dimension for Department Id.", 5, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_DEPARTMENT, "rocks.kfs.Intacct.DEPARTMENT" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Location", "The Intacct dimension for Location Id. Required if multi-entity enabled.", 6, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_LOCATION, "rocks.kfs.Intacct.LOCATION" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Credit Account", "Account number to use for credit column. Required by Intacct.", 1, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_CREDIT_ACCOUNT, "rocks.kfs.Intacct.ACCOUNTNO" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Debit Account", "Account number to use for debit column. Required by Intacct.", 2, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_DEBIT_ACCOUNT, "rocks.kfs.Intacct.DEBITACCOUNTNO" );
+            RockMigrationHelper.UpdateEntityAttribute( "Rock.Model.FinancialAccount", Rock.SystemGuid.FieldType.TEXT, "", "", "Transaction Fee Account", "Expense account number for gateway transaction fees.", 3, "", KFSConst.Attribute.FINANCIAL_ACCOUNT_FEE_ACCOUNT, "rocks.kfs.Intacct.FEEACCOUNTNO" );
+        }
+    }
+}

--- a/rocks.kfs.Intacct/Migrations/004_AddDebitAccountAttributes.cs
+++ b/rocks.kfs.Intacct/Migrations/004_AddDebitAccountAttributes.cs
@@ -4,7 +4,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//9DF341B7-2E07-44BA-94B1-F637BE551961
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -20,7 +20,7 @@ using KFSConst = rocks.kfs.Intacct.SystemGuid;
 
 namespace rocks.kfs.Intacct.Migrations
 {
-    [MigrationNumber( 4, "1.11.0" )]
+    [MigrationNumber( 4, "1.13.0" )]
     public class AddDebitAccountAttributes : Migration
     {
         /// <summary>

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.6.*" )]
+[assembly: AssemblyVersion( "2.7.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Intacct/SystemGuid/Attribute.cs
+++ b/rocks.kfs.Intacct/SystemGuid/Attribute.cs
@@ -39,6 +39,11 @@ namespace rocks.kfs.Intacct.SystemGuid
         public const string FINANCIAL_ACCOUNT_DEBIT_ACCOUNT = "48E1B80E-5E8D-4016-B64E-F2527F328EA7";
 
         /// <summary>
+        /// The Intacct dimension for Project.
+        /// </summary>
+        public const string FINANCIAL_ACCOUNT_PROJECT = "115519C9-EDFA-4BB5-A512-102C798F17F4";
+
+        /// <summary>
         /// The account number that transaction fees will be split into.
         /// </summary>
         public const string FINANCIAL_ACCOUNT_FEE_ACCOUNT = "AB69D108-59FF-4D07-94AA-ECD14FC7B2BD";
@@ -57,6 +62,26 @@ namespace rocks.kfs.Intacct.SystemGuid
         /// The Intacct dimension for Location.
         /// </summary>
         public const string FINANCIAL_ACCOUNT_LOCATION = "CFA818F9-3163-45FE-AA03-AAF8DEDCF48D";
+
+        /// <summary>
+        /// The Intacct dimension for Projects of debit account.
+        /// </summary>
+        public const string FINANCIAL_ACCOUNT_PROJECT_DEBIT = "9DF341B7-2E07-44BA-94B1-F637BE551961";
+
+        /// <summary>
+        /// The Intacct dimension for Class Id of debit account.
+        /// </summary>
+        public const string FINANCIAL_ACCOUNT_CLASS_DEBIT = "58B0B754-0B1C-4E4E-B396-3F8F046267E3";
+
+        /// <summary>
+        /// The Intacct dimension for Department of debit account.
+        /// </summary>
+        public const string FINANCIAL_ACCOUNT_DEPARTMENT_DEBIT = "5705FC91-0937-4F84-812F-730899E0114E";
+
+        /// <summary>
+        /// The Intacct dimension for Location of debit account.
+        /// </summary>
+        public const string FINANCIAL_ACCOUNT_LOCATION_DEBIT = "0F247FC0-ECF0-407F-A042-F8E3638ED5B4";
 
         #endregion
 

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -232,6 +232,7 @@ namespace rocks.kfs.Intacct.Utils
         public static SortedDictionary<string, dynamic> GetFilteredDimensions( SortedDictionary<string, dynamic> customDimenesionValues, string suffixExclude = null, string suffixRemove = null )
         {
             var filteredDimensions = new SortedDictionary<string, dynamic>();
+            var glDimPrefix = "GLDIM";
             if ( suffixExclude.IsNotNullOrWhiteSpace() )
             {
                 customDimenesionValues = new SortedDictionary<string, dynamic>( customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude.ToLower() ) ).ToDictionary( x => x.Key, x => x.Value ) );
@@ -240,9 +241,14 @@ namespace rocks.kfs.Intacct.Utils
             foreach ( var dimension in customDimenesionValues )
             {
                 var custFieldName = dimension.Key;
-                if ( suffixRemove.IsNotNullOrWhiteSpace() && dimension.Key.ToLower().EndsWith( suffixRemove.ToLower() ) )
+                if ( suffixRemove.IsNotNullOrWhiteSpace() && custFieldName.ToLower().EndsWith( suffixRemove.ToLower() ) )
                 {
-                    custFieldName = dimension.Key.Remove( dimension.Key.Length - suffixRemove.Length );
+                    custFieldName = custFieldName.Remove( custFieldName.Length - suffixRemove.Length );
+                }
+
+                if ( !custFieldName.ToUpper().StartsWith( glDimPrefix ) )
+                {
+                    custFieldName = glDimPrefix + custFieldName;
                 }
 
                 if ( !filteredDimensions.ContainsKey( custFieldName ) )

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -234,7 +234,7 @@ namespace rocks.kfs.Intacct.Utils
             var filteredDimensions = new SortedDictionary<string, dynamic>();
             if ( suffixExclude.IsNotNullOrWhiteSpace() )
             {
-                customDimenesionValues = new SortedDictionary<string, dynamic>( customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude ) ).ToDictionary( x => x.Key, x => x.Value ) );
+                customDimenesionValues = new SortedDictionary<string, dynamic>( customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude.ToLower() ) ).ToDictionary( x => x.Key, x => x.Value ) );
             }
 
             foreach ( var dimension in customDimenesionValues )

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -235,13 +235,15 @@ namespace rocks.kfs.Intacct.Utils
 
             foreach ( var dimension in customDimenesionValues )
             {
+                var custFieldName = dimension.Key;
                 if ( suffixRemove.IsNotNullOrWhiteSpace() && dimension.Key.ToLower().EndsWith( suffixRemove.ToLower() ) )
                 {
-                    filteredDimensions.Add( dimension.Key.Remove( dimension.Key.Length - suffixRemove.Length ), dimension.Value );
+                    custFieldName = dimension.Key.Remove( dimension.Key.Length - suffixRemove.Length );
                 }
-                else
+
+                if ( !filteredDimensions.ContainsKey( custFieldName ) )
                 {
-                    filteredDimensions.Add( dimension.Key, dimension.Value );
+                    filteredDimensions.Add( custFieldName, dimension.Value );
                 }
             }
             return filteredDimensions;

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -59,7 +59,8 @@ namespace rocks.kfs.Intacct.Utils
                     transactionDetail.Account.LoadAttributes();
 
                     var detailProject = transactionDetail.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
-                    var accountProject = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var accountProjectCredit = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.PROJECTID" ).AsGuidOrNull();
+                    var accountProjectDebit = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.DEBITPROJECTID" ).AsGuidOrNull();
                     var transactionFeeAccount = transactionDetail.Account.GetAttributeValue( "rocks.kfs.Intacct.FEEACCOUNTNO" );
 
                     if ( string.IsNullOrWhiteSpace( transactionFeeAccount ) )
@@ -67,14 +68,28 @@ namespace rocks.kfs.Intacct.Utils
                         transactionFeeAccount = gatewayDefaultFeeAccount;
                     }
 
-                    var projectCode = string.Empty;
+                    var creditProjectCode = string.Empty;
+                    var debitProjectCode = string.Empty;
                     if ( detailProject != null )
                     {
-                        projectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
+                        creditProjectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
+                        if ( accountProjectDebit != null )
+                        {
+                            debitProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectDebit ).Value;
+                        }
+                        else
+                        {
+                            debitProjectCode = creditProjectCode;
+                        }
                     }
-                    else if ( accountProject != null )
+                    else if ( accountProjectCredit != null )
                     {
-                        projectCode = DefinedValueCache.Get( ( Guid ) accountProject ).Value;
+                        creditProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectCredit ).Value;
+                    }
+
+                    if ( debitProjectCode.IsNullOrWhiteSpace() && accountProjectDebit != null )
+                    {
+                        debitProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectDebit ).Value;
                     }
 
                     if ( transactionDetail.EntityTypeId.HasValue )
@@ -112,7 +127,8 @@ namespace rocks.kfs.Intacct.Utils
                         Payer = transaction.AuthorizedPersonAlias.Person.FullName,
                         Amount = transactionDetail.Amount,
                         FinancialAccountId = transactionDetail.AccountId,
-                        Project = projectCode,
+                        CreditProject = creditProjectCode,
+                        DebitProject = debitProjectCode,
                         TransactionFeeAmount = transactionDetail.FeeAmount != null && ( transactionDetail.FeeAmount.Value > 0 || transactionDetail.FeeAmount.Value < 0 ) ? transactionDetail.FeeAmount.Value : 0.0M,
                         TransactionFeeAccount = transactionFeeAccount,
                         ProcessTransactionFees = processTransactionFees
@@ -127,12 +143,13 @@ namespace rocks.kfs.Intacct.Utils
             if ( groupingMode == GLAccountGroupingMode.DebitAndCreditByFinancialAccount )
             {
                 batchTransactionList = batchTransactions
-                    .GroupBy( d => new { d.FinancialAccountId, d.Project, d.TransactionFeeAccount, d.ProcessTransactionFees } )
+                    .GroupBy( d => new { d.FinancialAccountId, d.CreditProject, d.DebitProject, d.TransactionFeeAccount, d.ProcessTransactionFees } )
                     .Select( s => new GLTransaction
                     {
                         Payer = "Rock Import",
                         FinancialAccountId = s.Key.FinancialAccountId,
-                        Project = s.Key.Project,
+                        CreditProject = s.Key.CreditProject,
+                        DebitProject = s.Key.DebitProject,
                         Amount = s.Sum( f => ( decimal? ) f.Amount ) ?? 0.0M,
                         TransactionFeeAmount = s.Sum( f => ( decimal? ) f.TransactionFeeAmount ) ?? 0.0M,
                         TransactionFeeAccount = s.Key.TransactionFeeAccount,
@@ -160,6 +177,10 @@ namespace rocks.kfs.Intacct.Utils
             knownDimensions.Add( "rocks.kfs.Intacct.DEPARTMENT" );
             knownDimensions.Add( "rocks.kfs.Intacct.LOCATION" );
             knownDimensions.Add( "rocks.kfs.Intacct.PROJECTID" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEBITCLASSID" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEBITDEPARTMENT" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEBITLOCATION" );
+            knownDimensions.Add( "rocks.kfs.Intacct.DEBITPROJECTID" );
 
             var rockContext = new RockContext();
             var accountCategoryId = new CategoryService( rockContext ).Queryable().FirstOrDefault( c => c.Guid.Equals( new System.Guid( KFSConst.Attribute.FINANCIAL_ACCOUNT_ATTRIBUTE_CATEGORY ) ) ).Id;
@@ -206,6 +227,28 @@ namespace rocks.kfs.Intacct.Utils
             }
 
             return mergeFields;
+        }
+
+        public static Dictionary<string, dynamic> GetFilteredDimensions( Dictionary<string, dynamic> customDimenesionValues, string suffixExclude = null, string suffixRemove = null )
+        {
+            var filteredDimensions = new Dictionary<string, dynamic>();
+            if ( suffixExclude.IsNotNullOrWhiteSpace() )
+            {
+                customDimenesionValues = customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude ) ).ToDictionary( x => x.Key, x => x.Value );
+            }
+
+            foreach ( var dimension in customDimenesionValues )
+            {
+                if ( suffixRemove.IsNotNullOrWhiteSpace() && dimension.Key.ToLower().EndsWith( suffixRemove.ToLower() ) )
+                {
+                    filteredDimensions.Add( dimension.Key.Remove( dimension.Key.Length - suffixRemove.Length ), dimension.Value );
+                }
+                else
+                {
+                    filteredDimensions.Add( dimension.Key, dimension.Value );
+                }
+            }
+            return filteredDimensions;
         }
     }
 

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -206,7 +206,11 @@ namespace rocks.kfs.Intacct.Utils
                 foreach ( var rockKey in mergeFieldObjects.CustomDimensions )
                 {
                     var dimension = rockKey.Split( '.' ).Last();
-                    customDimensionValues.Add( dimension, account.GetAttributeValue( rockKey ) );
+                    var value = account.GetAttributeValue( rockKey );
+                    if ( value.IsNotNullOrWhiteSpace() )
+                    {
+                        customDimensionValues.Add( dimension, account.GetAttributeValue( rockKey ) );
+                    }
                 }
             }
 

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -229,12 +229,12 @@ namespace rocks.kfs.Intacct.Utils
             return mergeFields;
         }
 
-        public static Dictionary<string, dynamic> GetFilteredDimensions( Dictionary<string, dynamic> customDimenesionValues, string suffixExclude = null, string suffixRemove = null )
+        public static SortedDictionary<string, dynamic> GetFilteredDimensions( SortedDictionary<string, dynamic> customDimenesionValues, string suffixExclude = null, string suffixRemove = null )
         {
-            var filteredDimensions = new Dictionary<string, dynamic>();
+            var filteredDimensions = new SortedDictionary<string, dynamic>();
             if ( suffixExclude.IsNotNullOrWhiteSpace() )
             {
-                customDimenesionValues = customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude ) ).ToDictionary( x => x.Key, x => x.Value );
+                customDimenesionValues = new SortedDictionary<string, dynamic>( customDimenesionValues.Where( d => !d.Key.ToLower().EndsWith( suffixExclude ) ).ToDictionary( x => x.Key, x => x.Value ) );
             }
 
             foreach ( var dimension in customDimenesionValues )

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -73,23 +73,19 @@ namespace rocks.kfs.Intacct.Utils
                     if ( detailProject != null )
                     {
                         creditProjectCode = DefinedValueCache.Get( ( Guid ) detailProject ).Value;
+                        debitProjectCode = creditProjectCode;
+                    }
+                    else
+                    {
                         if ( accountProjectDebit != null )
                         {
                             debitProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectDebit ).Value;
                         }
-                        else
-                        {
-                            debitProjectCode = creditProjectCode;
-                        }
-                    }
-                    else if ( accountProjectCredit != null )
-                    {
-                        creditProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectCredit ).Value;
-                    }
 
-                    if ( debitProjectCode.IsNullOrWhiteSpace() && accountProjectDebit != null )
-                    {
-                        debitProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectDebit ).Value;
+                        if ( accountProjectCredit != null )
+                        {
+                            creditProjectCode = DefinedValueCache.Get( ( Guid ) accountProjectCredit ).Value;
+                        }
                     }
 
                     if ( transactionDetail.EntityTypeId.HasValue )

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -196,7 +196,7 @@ namespace rocks.kfs.Intacct.Utils
             return customDimensions;
         }
 
-        public static Dictionary<string, object> GetMergeFieldsAndDimensions( ref string debugLava, Dictionary<string, dynamic> customDimensionValues, MergeFieldObjects mergeFieldObjects )
+        public static Dictionary<string, object> GetMergeFieldsAndDimensions( ref string debugLava, SortedDictionary<string, dynamic> customDimensionValues, MergeFieldObjects mergeFieldObjects )
         {
             var mergeFields = new Dictionary<string, object>();
             var account = mergeFieldObjects.Account;

--- a/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
+++ b/rocks.kfs.Intacct/Utils/TransactionHelpers.cs
@@ -209,7 +209,7 @@ namespace rocks.kfs.Intacct.Utils
                     var value = account.GetAttributeValue( rockKey );
                     if ( value.IsNotNullOrWhiteSpace() )
                     {
-                        customDimensionValues.Add( dimension, account.GetAttributeValue( rockKey ) );
+                        customDimensionValues.Add( dimension, value );
                     }
                 }
             }

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -85,6 +85,7 @@
     <Compile Include="IntacctOtherReceipt.cs" />
     <Compile Include="IntacctJournal.cs" />
     <Compile Include="IntacctModels.cs" />
+    <Compile Include="Migrations\004_AddDebitAccountAttributes.cs" />
     <Compile Include="Migrations\003_AddBatchesToIntacct.cs" />
     <Compile Include="Migrations\002_AddTransactionFeeAttributes.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added new debit account specific classification attributes and support for grouping by them. Also added support for grouping by custom dimensions when using a GL account grouping mode.

**New Attributes:**

- Default Debit Project
- Debit Class
- Debit Department
- Debit Location

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

See https://github.com/KingdomFirst/RockBlocks/pull/147

---------

### Requested By

##### Who reported, requested, or paid for the change?

The Father's House

---------

### Screenshots

##### Does this update or add options to the block UI?

Financial Account Attribute Changes:  
![image](https://github.com/KingdomFirst/RockAssemblies/assets/7374281/d2a9299d-c07d-48de-926a-f3a0c16861dc)
  
---------

### Change Log

##### What files does it affect?

* rocks.kfs.Intacct/IntacctJournal.cs
* rocks.kfs.Intacct/IntacctModels.cs
* rocks.kfs.Intacct/IntacctOtherReceipt.cs
* rocks.kfs.Intacct/Migrations/001_AddSystemData.cs
* rocks.kfs.Intacct/Migrations/002_AddTransactionFeeAttributes.cs
* rocks.kfs.Intacct/Migrations/003_AddBatchesToIntacct.cs
* rocks.kfs.Intacct/Migrations/004_AddDebitAccountAttributes.cs
* rocks.kfs.Intacct/Properties/AssemblyInfo.cs
* rocks.kfs.Intacct/SystemGuid/Attribute.cs
* rocks.kfs.Intacct/Utils/TransactionHelpers.cs
* rocks.kfs.Intacct/rocks.kfs.Intacct.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
