### PR TITLE
Rename to Round Robin Group Assignment

### DIFF
--- a/KFSRock.sln.kfs
+++ b/KFSRock.sln.kfs
@@ -164,7 +164,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.Zoom", "KFSRockAs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZoomDotNetFramework", "KFSRockAssemblies\ZoomDotNetFramework\ZoomDotNetFramework.csproj", "{99DA9675-2596-43B9-A623-0AD3C742FD3C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.GroupRoundRobinAssignment", "KFSRockAssemblies\rocks.kfs.GroupRoundRobinAssignment\rocks.kfs.GroupRoundRobinAssignment.csproj", "{E2040E07-572B-4629-8B9F-6B53EC7C077C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.RoundRobinGroupAssignment", "KFSRockAssemblies\rocks.kfs.RoundRobinGroupAssignment\rocks.kfs.RoundRobinGroupAssignment.csproj", "{E2040E07-572B-4629-8B9F-6B53EC7C077C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "rocks.kfs.CustomGroupCommunication", "KFSRockAssemblies\rocks.kfs.CustomGroupCommunication\rocks.kfs.CustomGroupCommunication.csproj", "{CB69A1A9-DFD2-40D0-829B-AF9558DEBFD2}"
 EndProject

--- a/rocks.kfs.RoundRobinGroupAssignment/Jobs/RoundRobinGroupAssignment.cs
+++ b/rocks.kfs.RoundRobinGroupAssignment/Jobs/RoundRobinGroupAssignment.cs
@@ -27,10 +27,10 @@ using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
 
-namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
+namespace rocks.kfs.RoundRobinGroupAssignment.Jobs
 {
     /// <summary>
-    /// Job to process Group Round Robin Assignments
+    /// Job to process Round Robin Group Assignment
     /// </summary>
     ///
     [DataViewField(
@@ -116,7 +116,7 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
 
 
     [DisallowConcurrentExecution]
-    public class GroupRoundRobinAssignment : IJob
+    public class RoundRobinGroupAssignment : IJob
     {
         /// <summary>
         /// Attribute Keys
@@ -139,7 +139,7 @@ namespace rocks.kfs.GroupRoundRobinAssignment.Jobs
         /// <summary>
         /// Initializes a new instance of the <see cref="GroupRoundRobinAssignment"/> class.
         /// </summary>
-        public GroupRoundRobinAssignment()
+        public RoundRobinGroupAssignment()
         {
         }
 

--- a/rocks.kfs.RoundRobinGroupAssignment/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.RoundRobinGroupAssignment/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle( "rocks.kfs.GroupRoundRobinAssignment" )]
-[assembly: AssemblyProduct( "rocks.kfs.GroupRoundRobinAssignment" )]
+[assembly: AssemblyTitle( "rocks.kfs.RoundRobinGroupAssignment" )]
+[assembly: AssemblyProduct( "rocks.kfs.RoundRobinGroupAssignment" )]
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions

--- a/rocks.kfs.RoundRobinGroupAssignment/rocks.kfs.RoundRobinGroupAssignment.csproj
+++ b/rocks.kfs.RoundRobinGroupAssignment/rocks.kfs.RoundRobinGroupAssignment.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{E2040E07-572B-4629-8B9F-6B53EC7C077C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>rocks.kfs.GroupRoundRobinAssignment</RootNamespace>
-    <AssemblyName>rocks.kfs.GroupRoundRobinAssignment</AssemblyName>
+    <RootNamespace>rocks.kfs.RoundRobinGroupAssignment</RootNamespace>
+    <AssemblyName>rocks.kfs.RoundRobinGroupAssignment</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -51,7 +51,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Jobs\GroupRoundRobinAssignment.cs" />
+    <Compile Include="Jobs\RoundRobinGroupAssignment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Rename everything to RoundRobinGroupAssignment

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Rename everything to RoundRobinGroupAssignment

---------

### Requested By

##### Who reported, requested, or paid for the change?

College

---------

### Screenshots

##### Does this update or add options to the block UI?

![JobConfiguration_NoNumbers](https://github.com/KingdomFirst/RockAssemblies/assets/2990519/f792abc4-e8c7-49dd-ab0c-39a0814bd46b)
![RoundRobinAssignment](https://github.com/KingdomFirst/RockAssemblies/assets/2990519/ecf85deb-a48a-4680-a2c3-9329e5bab3c3)
![JobConfiguration](https://github.com/KingdomFirst/RockAssemblies/assets/2990519/63104ff9-388e-48c2-ba7e-d92a153c0757)

---------

### Change Log

##### What files does it affect?

- KFSRock.sln.kfs
- rocks.kfs.RoundRobinGroupAssignment/Jobs/RoundRobinGroupAssignment.cs
- rocks.kfs.RoundRobinGroupAssignment/Properties/AssemblyInfo.cs
- rocks.kfs.RoundRobinGroupAssignment/rocks.kfs.RoundRobinGroupAssignment.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, any dev environments will need to be updated with new sln file or re-locate the new project in current solution.