### PR TITLE
Group Meeting Reminders v14+ Build and Bug fix

### DIFF
--- a/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
+++ b/rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
@@ -139,7 +139,7 @@ namespace rocks.kfs.CustomGroupCommunication.Jobs
                             .Where( g =>
                                 g.IsActive &&
                                 g.Schedule != null )
-                            .WhereAttributeValue( rockContext, av => av.Attribute.Guid.Equals( groupAttributeSetting ) );
+                            .WhereAttributeValue( rockContext, av => av.Attribute.Guid.Equals( groupAttributeSetting ) && av.ValueAsBoolean == true );
 
             foreach ( var group in groupQuery.ToList() )
             {

--- a/rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2022 by Kingdom First Solutions
+// Copyright 2023 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.CustomGroupCommunication" )]
 [assembly: AssemblyProduct( "rocks.kfs.CustomGroupCommunication" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.0.*" )]
+[assembly: AssemblyVersion( "1.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Update version to rebuild for v14+ with new iCal reference and found a bug that it was not actually honoring no/false on the attribute.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed a reference exception when running with v14+ of Rock. (Fixes #136)
- Updated logic to honor "no" on the boolean attribute.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.CustomGroupCommunication/Jobs/MeetingGroupReminder.cs
- rocks.kfs.CustomGroupCommunication/Properties/AssemblyInfo.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, technically 14+ only will have the fix for the boolean "no/false" and has to have a specific dll build for version support.
