### PR TITLE
Financial context update

### DIFF
--- a/rocks.kfs.FinancialEdge/Migrations/004_AddContextAttribute.cs
+++ b/rocks.kfs.FinancialEdge/Migrations/004_AddContextAttribute.cs
@@ -1,0 +1,54 @@
+﻿// <copyright>
+// Copyright 2024 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.FinancialEdge.Migrations
+{
+    [MigrationNumber( 4, "1.13.0" )]
+    public class AddContextAttribute : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // Attribute for BlockType
+            //   BlockType: Financial Edge Batch to Journal
+            //   Category: KFS > Financial Edge
+            //   Attribute: Entity Type
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "CC716B06-4674-4CBE-9C66-E7DCB42153CB", "3549BAB6-FE1B-4333-AFC4-C5ACA01BB8EB", "Entity Type", "ContextEntityType", "Entity Type", @"The type of entity that will provide context for this block", 0, @"", "D90B23E8-3C5B-4CCA-A8F8-025A53D8931E" );
+
+            // Add Block Attribute Value
+            //   Block: Financial Edge Batch To Journal
+            //   BlockType: Financial Edge Batch to Journal
+            //   Category: KFS > Financial Edge
+            //   Block Location: Page=Financial Batch Detail, Site=Rock RMS
+            //   Attribute: Entity Type
+            /*   Attribute Value: bdd09c8e-2c52-4d08-9062-be7d52d190c2 */
+            //   Skip If Already Exists: true
+            RockMigrationHelper.AddBlockAttributeValue( true, "EAB705EF-22AF-4A6E-9531-A094AB913DC3", "D90B23E8-3C5B-4CCA-A8F8-025A53D8931E", @"bdd09c8e-2c52-4d08-9062-be7d52d190c2" );
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( "D90B23E8-3C5B-4CCA-A8F8-025A53D8931E" );
+        }
+    }
+}

--- a/rocks.kfs.FinancialEdge/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.FinancialEdge/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.FinancialEdge" )]
 [assembly: AssemblyProduct( "rocks.kfs.FinancialEdge" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2022" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.2.*" )]
+[assembly: AssemblyVersion( "2.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.FinancialEdge/rocks.kfs.FinancialEdge.csproj
+++ b/rocks.kfs.FinancialEdge/rocks.kfs.FinancialEdge.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FEJournal.cs" />
+    <Compile Include="Migrations\004_AddContextAttribute.cs" />
     <Compile Include="Migrations\003_AddDebitProject.cs" />
     <Compile Include="Migrations\002_AddMultipeBatchExport.cs" />
     <Compile Include="Migrations\001_AddSystemData.cs" />

--- a/rocks.kfs.Intacct/Migrations/005_AddContextAttribute.cs
+++ b/rocks.kfs.Intacct/Migrations/005_AddContextAttribute.cs
@@ -1,0 +1,57 @@
+﻿// <copyright>
+// Copyright 2024 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.Intacct.SystemGuid;
+
+namespace rocks.kfs.Intacct.Migrations
+{
+    [MigrationNumber( 5, "1.13.0" )]
+    public class AddContextAttribute : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // Attribute for BlockType
+            //   BlockType: Intacct Batch to Journal
+            //   Category: KFS > Intacct
+            //   Attribute: Entity Type
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "5F859264-2E47-41FF-AA63-B57FE400BBC2", "3549BAB6-FE1B-4333-AFC4-C5ACA01BB8EB", "Entity Type", "ContextEntityType", "Entity Type", @"The type of entity that will provide context for this block", 0, @"", "D8AEDEAC-DFB7-410D-8393-4094E3D91277" );
+
+            // Add Block Attribute Value
+            //   Block: Intacct Batch to Journal
+            //   BlockType: Intacct Batch to Journal
+            //   Category: KFS > Intacct
+            //   Block Location: Page=Financial Batch Detail, Site=Rock RMS
+            //   Attribute: Entity Type
+            /*   Attribute Value: bdd09c8e-2c52-4d08-9062-be7d52d190c2 */
+            //   Skip If Already Exists: true
+            RockMigrationHelper.AddBlockAttributeValue( true, "328FD600-A246-4326-A00C-943A4DF7DC39", "D8AEDEAC-DFB7-410D-8393-4094E3D91277", @"bdd09c8e-2c52-4d08-9062-be7d52d190c2" );
+
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( "D8AEDEAC-DFB7-410D-8393-4094E3D91277" );
+        }
+    }
+}

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.Intacct" )]
 [assembly: AssemblyProduct( "rocks.kfs.Intacct" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.7.*" )]
+[assembly: AssemblyVersion( "2.8.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
+++ b/rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
@@ -85,6 +85,7 @@
     <Compile Include="IntacctOtherReceipt.cs" />
     <Compile Include="IntacctJournal.cs" />
     <Compile Include="IntacctModels.cs" />
+    <Compile Include="Migrations\005_AddContextAttribute.cs" />
     <Compile Include="Migrations\004_AddDebitAccountAttributes.cs" />
     <Compile Include="Migrations\003_AddBatchesToIntacct.cs" />
     <Compile Include="Migrations\002_AddTransactionFeeAttributes.cs" />

--- a/rocks.kfs.ShelbyFinancials/Migrations/005_AddContextAttribute.cs
+++ b/rocks.kfs.ShelbyFinancials/Migrations/005_AddContextAttribute.cs
@@ -1,0 +1,58 @@
+﻿// <copyright>
+// Copyright 2024 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using Rock.Plugin;
+using KFSConst = rocks.kfs.ShelbyFinancials.SystemGuid;
+
+namespace rocks.kfs.ShelbyFinancials.Migrations
+{
+    [MigrationNumber( 5, "1.13.0" )]
+    public class AddContextAttribute : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // Attribute for BlockType
+            //   BlockType: Shelby Financials Batch to Journal
+            //   Category: KFS > Shelby Financials
+            //   Attribute: Entity Type
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "235C370C-2CD7-4289-8B68-A8617F58B22B", "3549BAB6-FE1B-4333-AFC4-C5ACA01BB8EB", "Entity Type", "ContextEntityType", "Entity Type", @"The type of entity that will provide context for this block", 0, @"", "4F7F5998-D969-4CF3-9BDD-DC8954624CB4" );
+
+            // Add Block Attribute Value
+            //   Block: Shelby Financials Batch To Journal
+            //   BlockType: Shelby Financials Batch to Journal
+            //   Category: KFS > Shelby Financials
+            //   Block Location: Page=Financial Batch Detail, Site=Rock RMS
+            //   Attribute: Entity Type
+            /*   Attribute Value: bdd09c8e-2c52-4d08-9062-be7d52d190c2 */
+            //   Skip If Already Exists: true
+            RockMigrationHelper.AddBlockAttributeValue( true, "00FC3A61-775D-4DE5-BC19-A1556FF465EA", "4F7F5998-D969-4CF3-9BDD-DC8954624CB4", @"bdd09c8e-2c52-4d08-9062-be7d52d190c2" );
+
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( "4F7F5998-D969-4CF3-9BDD-DC8954624CB4" );
+
+        }
+    }
+}

--- a/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.ShelbyFinancials" )]
 [assembly: AssemblyProduct( "rocks.kfs.ShelbyFinancials" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.6.*" )]
+[assembly: AssemblyVersion( "2.7.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj
+++ b/rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Migrations\005_AddContextAttribute.cs" />
     <Compile Include="Migrations\004_AddTransactionFeeAttributes.cs" />
     <Compile Include="Migrations\003_AddCreditCostCenter.cs" />
     <Compile Include="Migrations\002_AddDebitAccountSub.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added ContextAware to all of our financial plugin blocks for future version support with hashed id's. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added context support to blocks and default attribute values via migrations.

---------

### Requested By

##### Who reported, requested, or paid for the change?

MHC, Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.FinancialEdge/Migrations/004_AddContextAttribute.cs
- rocks.kfs.FinancialEdge/Properties/AssemblyInfo.cs
- rocks.kfs.FinancialEdge/rocks.kfs.FinancialEdge.csproj
- rocks.kfs.Intacct/Migrations/005_AddContextAttribute.cs
- rocks.kfs.Intacct/Properties/AssemblyInfo.cs
- rocks.kfs.Intacct/rocks.kfs.Intacct.csproj
- rocks.kfs.ShelbyFinancials/Migrations/005_AddContextAttribute.cs
- rocks.kfs.ShelbyFinancials/Properties/AssemblyInfo.cs
- rocks.kfs.ShelbyFinancials/rocks.kfs.ShelbyFinancials.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Technically no, this is better supported. Blocks do have to be updated with migrations otherwise it can cause them not to work as expected updates in https://github.com/KingdomFirst/RockBlocks/pull/160
