### PR TITLE
Intacct Negative Transaction Fee Fix

### DIFF
--- a/rocks.kfs.Intacct/IntacctJournal.cs
+++ b/rocks.kfs.Intacct/IntacctJournal.cs
@@ -264,8 +264,8 @@ namespace rocks.kfs.Intacct
             var returnList = new List<JournalEntryLine>();
             var debitTransactions = transactionItems.Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
             var creditTransactions = transactionItems.Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
-            var feeDebitTransactions = transactionItems.Where( f => f.TransactionFeeAmount > 0.0M && !string.IsNullOrWhiteSpace( f.TransactionFeeAccount ) && f.ProcessTransactionFees > 0 ).Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
-            var feeCreditTransactions = transactionItems.Where( f => f.TransactionFeeAmount > 0.0M && !string.IsNullOrWhiteSpace( f.TransactionFeeAccount ) && f.ProcessTransactionFees == 2 ).Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
+            var feeDebitTransactions = transactionItems.Where( f => ( f.TransactionFeeAmount > 0.0M || f.TransactionFeeAmount < 0.0M ) && !string.IsNullOrWhiteSpace( f.TransactionFeeAccount ) && f.ProcessTransactionFees > 0 ).Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
+            var feeCreditTransactions = transactionItems.Where( f => ( f.TransactionFeeAmount > 0.0M || f.TransactionFeeAmount < 0.0M ) && !string.IsNullOrWhiteSpace( f.TransactionFeeAccount ) && f.ProcessTransactionFees == 2 ).Select( ti => ( GLBatchTotals ) ti.Clone() ).ToList();
 
             // Condition and prepare debit entries
             foreach ( var t in debitTransactions )

--- a/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Intacct/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.8.*" )]
+[assembly: AssemblyVersion( "2.8.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for negative transaction fees again. Similar to #82 but in the new code

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an issue that refunded transaction fees would not export properly to Intacct.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Intacct/IntacctJournal.cs
---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
