### PR TITLE
Cybersource Gateway Update - Event Registration Address Mode

### DIFF
--- a/rocks.kfs.CyberSource/Gateway.cs
+++ b/rocks.kfs.CyberSource/Gateway.cs
@@ -107,6 +107,14 @@ namespace rocks.kfs.CyberSource
         DefaultBooleanValue = false,
         Order = 7 )]
 
+    [CustomDropdownListField(
+        "Event Registration Address Mode",
+        Key = AttributeKey.EventRegistrationAddressMode,
+        Description = @"The mode for address input on the Gateway with event registrations. In order to use 'Hide' or 'Optional' you must have Relaxed AVS enabled by the processor.",
+        ListSource = "Hide,Optional,Required",
+        DefaultValue = "Required",
+        Order = 7 )]
+
     #endregion
 
     /// <summary>
@@ -130,6 +138,7 @@ namespace rocks.kfs.CyberSource
             public const string BatchPrefix = "BatchPrefix";
             public const string Mode = "Mode";
             public const string CapturePayment = "CapturePayment";
+            public const string EventRegistrationAddressMode = "EventRegistrationAddressMode";
 
             /// <summary>
             /// The credit card fee coverage percentage
@@ -1555,6 +1564,7 @@ namespace rocks.kfs.CyberSource
             return new
             {
                 gatewayUrl = GetGatewayUrl( financialGateway ),
+                addressMode = financialGateway.GetAttributeValue( AttributeKey.EventRegistrationAddressMode ),
                 microFormJsPath,
                 microFormJWK,
                 jwkGeneratedTime = millisecondsSinceEpoch

--- a/rocks.kfs.CyberSource/Gateway.cs
+++ b/rocks.kfs.CyberSource/Gateway.cs
@@ -113,7 +113,7 @@ namespace rocks.kfs.CyberSource
         Description = @"The mode for address input on the Gateway with event registrations. In order to use 'Hide' or 'Optional' you must have Relaxed AVS enabled by the processor.",
         ListSource = "Hide,Optional,Required",
         DefaultValue = "Required",
-        Order = 7 )]
+        Order = 8 )]
 
     #endregion
 

--- a/rocks.kfs.CyberSource/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.CyberSource/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.1.*" )]
+[assembly: AssemblyVersion( "1.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
+++ b/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
@@ -7,9 +7,9 @@
 
         <div v-show="!loading && !failedToLoad" style="max-width: 600px;">
             <div :id="controlId" class="js-cybersource-payment-inputs cybersource-payment-inputs" ref="paymentInputs">
-                <div class="gateway-address-container js-gateway-address-container">
+                <div class="gateway-address-container js-gateway-address-container" ref="addressContainer" v-show="showAddress">
                     <h4>Billing</h4>
-                    <AddressControl label="Address" v-model="address" :disabled="isSaving" :rules="'required'" />
+                    <AddressControl label="Address" v-model="address" :disabled="isSaving" :rules="addressRules" />
                 </div>
                 <div class="gateway-creditcard-container gateway-payment-container js-gateway-creditcard-container" >
                     <h4>Payment</h4>
@@ -177,6 +177,7 @@
      */
     type Settings = {
         gatewayUrl: string;
+        addressMode: string;
         microFormJsPath: string;
         microFormJWK: string;
         jwkGeneratedTime: number;
@@ -244,6 +245,8 @@
      *  // @ts-ignore above each line in the addressControl.obs file that generated an exception.
      */
     const address = ref<AddressControlBag | undefined>(props.settings.address ?? undefined);
+    const showAddress = ref(true);
+    const addressRules = ref("");
 
     /**
      * Contains a unique identifier that we can use to allow MicroformJS
@@ -637,6 +640,12 @@
                 number: undefined,
                 securityCode: undefined
             };
+
+            showAddress.value = props.settings.addressMode != "Hide";
+
+            if (props.settings.addressMode == "Required") {
+                addressRules.value = "required";
+            }
 
             initCybersourceMicroFormFields();
         }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add Event Registration Address Mode setting to Gateway and control.

**New Settings:**

_Event Registration Address Mode_, The mode for address input on the Gateway with event registrations. In order to use 'Hide' or 'Optional' you must have Relaxed AVS enabled by the processor.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Added new Gateway setting "Event Registration Address Mode"

---------

### Requested By

##### Who reported, requested, or paid for the change?

Island

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/user-attachments/assets/5b60f1da-b408-4f0e-a4cc-c041c037bc46)

---------

### Change Log

##### What files does it affect?

- rocks.kfs.CyberSource/Gateway.cs
- rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
