### PR TITLE
Scheduled Group Communication Bug

### DIFF
--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
@@ -79,6 +79,8 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
             {
                 using ( var rockContext = new RockContext() )
                 {
+                    rockContext.Database.CommandTimeout = commandTimeout;
+
                     // get the last run date or yesterday
                     DateTime? lastStartDateTime = null;
 

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs
@@ -77,6 +77,8 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
             {
                 using ( var rockContext = new RockContext() )
                 {
+                    rockContext.Database.CommandTimeout = commandTimeout;
+
                     // get the last run date or yesterday
                     DateTime? lastStartDateTime = null;
 
@@ -177,24 +179,17 @@ namespace rocks.kfs.ScheduledGroupCommunication.Jobs
                                 var personIdHash = new HashSet<int>();
                                 foreach ( var groupMember in recipients )
                                 {
-                                    // Use a new context to limit the amount of change-tracking required
-                                    using ( var groupMemberContext = new RockContext() )
+                                    if ( !personIdHash.Contains( groupMember.PersonId ) )
                                     {
-                                        if ( !personIdHash.Contains( groupMember.PersonId ) )
+                                        if ( groupMember.Person != null && groupMember.Person.PrimaryAliasId.HasValue )
                                         {
-                                            var person = new PersonService( groupMemberContext )
-                                                .GetNoTracking( groupMember.PersonId );
-
-                                            if ( person != null && person.PrimaryAliasId.HasValue )
-                                            {
-                                                personIdHash.Add( groupMember.PersonId );
-                                                var communicationRecipient = new CommunicationRecipient();
-                                                communicationRecipient.PersonAliasId = person.PrimaryAliasId;
-                                                communicationRecipient.AdditionalMergeValues = new Dictionary<string, object>();
-                                                communicationRecipient.AdditionalMergeValues.Add( "GroupMember", groupMember );
-                                                //communicationRecipient.AdditionalMergeValues.Add( "Group", group );
-                                                communication.Recipients.Add( communicationRecipient );
-                                            }
+                                            personIdHash.Add( groupMember.PersonId );
+                                            var communicationRecipient = new CommunicationRecipient();
+                                            communicationRecipient.PersonAliasId = groupMember.Person.PrimaryAliasId;
+                                            communicationRecipient.AdditionalMergeValues = new Dictionary<string, object>();
+                                            communicationRecipient.AdditionalMergeValues.Add( "GroupMember", groupMember );
+                                            //communicationRecipient.AdditionalMergeValues.Add( "Group", group );
+                                            communication.Recipients.Add( communicationRecipient );
                                         }
                                     }
                                 }

--- a/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.ScheduledGroupCommunication/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2023 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.ScheduledGroupCommunication" )]
 [assembly: AssemblyProduct( "rocks.kfs.ScheduledGroupCommunication" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2023" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.1.*" )]
+[assembly: AssemblyVersion( "2.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Add two additional CommandTimeout set points. 
- Remove unnecessary query on each recipient for ScheduledGroupSMS.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed a bug with Send Scheduled Group SMS reloading each recipient and causing unnecessary database calls.

---------

### Requested By

##### Who reported, requested, or paid for the change?

KCC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupEmail.cs
- rocks.kfs.ScheduledGroupCommunication/Jobs/SendScheduledGroupSMS.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, though only tested v16.3+.
