### PR TITLE
Steps To Care Auto Assign Worker Bug Fix

### DIFF
--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.StepsToCare" )]
 [assembly: AssemblyProduct( "rocks.kfs.StepsToCare" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.0.1.*" )]
+[assembly: AssemblyVersion( "2.0.2.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.0.2.*" )]
+[assembly: AssemblyVersion( "2.0.3.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -476,7 +476,7 @@ namespace rocks.kfs.StepsToCare
                     }
                 }
 
-                var currentlyAssignedPeople = careAssigneeService.Queryable().AsNoTracking().Where( ap => ap.CareNeed.StatusValueId != closedStatusId );
+                var currentlyAssignedPeople = careAssigneeService.Queryable().AsNoTracking();
 
                 if ( categoryGroups.Any() )
                 {
@@ -515,7 +515,7 @@ namespace rocks.kfs.StepsToCare
                 .AsNoTracking()
                 .Where( gm => !gm.IsArchived
                               && gm.GroupMemberStatus == GroupMemberStatus.Active )
-                .OrderBy( gm => currentlyAssignedPeople.Count( ap => ap.PersonAlias.PersonId == gm.Person.Id ) )
+                .OrderBy( gm => currentlyAssignedPeople.Count( ap => ap.PersonAlias.PersonId == gm.Person.Id && ap.CareNeed.StatusValueId != closedStatusId ) )
                 .ThenBy( gm => currentlyAssignedPeople.Where( ap => ap.PersonAlias.PersonId == gm.Person.Id ).OrderByDescending( ap => ap.CreatedDateTime ).Select( ap => ap.CreatedDateTime ).FirstOrDefault() )
                 .ToList();
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed https://github.com/KingdomFirst/RockAssemblies/issues/170

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed bug causing unpredictable results when workers are auto-assigned based on load balancing based on group membership when multiple members have zero care needs assigned to them that are not Closed.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty/Bug

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* rocks.kfs.StepsToCare/Utilities.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
