### PR TITLE
Steps to Care History

### DIFF
--- a/rocks.kfs.StepsToCare/Migrations/019_AddFieldTypeAndAttributeMatrix.cs
+++ b/rocks.kfs.StepsToCare/Migrations/019_AddFieldTypeAndAttributeMatrix.cs
@@ -37,7 +37,7 @@ namespace rocks.kfs.StepsToCare.Migrations
                 IsActive = true,
                 FormattedLava = AttributeMatrixTemplate.FormattedLavaDefault,
                 CreatedDateTime = RockDateTime.Now,
-                Guid = SystemGuid.Attribute.CATEGORY_MATRIX_CARE_TOUCHES.AsGuid()
+                Guid = SystemGuid.Category.MATRIX_CARE_TOUCHES.AsGuid()
             };
 
             var rockContext = new RockContext();
@@ -48,7 +48,7 @@ namespace rocks.kfs.StepsToCare.Migrations
                 rockContext.SaveChanges();
             } );
 
-            var attributeMatrixTemplateId = attributeMatrixTemplateService.Get( SystemGuid.Attribute.CATEGORY_MATRIX_CARE_TOUCHES.AsGuid() ).Id.ToString();
+            var attributeMatrixTemplateId = attributeMatrixTemplateService.Get( SystemGuid.Category.MATRIX_CARE_TOUCHES.AsGuid() ).Id.ToString();
 
             // Entity: Rock.Model.AttributeMatrixItem Attribute: Note Template
             RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.AttributeMatrixItem", SystemGuid.FieldType.NOTE_TEMPLATE, "AttributeMatrixTemplateId", attributeMatrixTemplateId, "Note Template", "Note Template", @"", 0, @"", SystemGuid.Attribute.MATRIX_ATTRIBUTE_TOUCH_NOTE_TEMPLATE, "NoteTemplate" );
@@ -98,7 +98,7 @@ namespace rocks.kfs.StepsToCare.Migrations
 
             var rockContext = new RockContext();
             var attributeMatrixTemplateService = new AttributeMatrixTemplateService( rockContext );
-            var attributeMatrixTemplate = attributeMatrixTemplateService.Get( SystemGuid.Attribute.CATEGORY_MATRIX_CARE_TOUCHES.AsGuid() );
+            var attributeMatrixTemplate = attributeMatrixTemplateService.Get( SystemGuid.Category.MATRIX_CARE_TOUCHES.AsGuid() );
             rockContext.WrapTransaction( () =>
             {
                 attributeMatrixTemplateService.Delete( attributeMatrixTemplate );

--- a/rocks.kfs.StepsToCare/Migrations/023_UpdateAttributes.cs
+++ b/rocks.kfs.StepsToCare/Migrations/023_UpdateAttributes.cs
@@ -72,11 +72,11 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.AddAttributeQualifier( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS, "values", groupSelectSql, "B544C383-CCBA-4D80-B86E-F843F4AF0453" );
 
             RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Minimum Follow Up Care Touch Hours", "MinimumFollowUpTouchHours", "Minimum Follow Up Care Touch Hours", @"Minimum hours for the follow up worker to add a care touch before the need gets 'flagged'.", 4, @"24", "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE" );
-            RockMigrationHelper.AddBlockAttributeValue( "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE", "8945BE62-D065-4A19-89A8-B06CE51FFBFF", @"24" );
+            RockMigrationHelper.AddBlockAttributeValue( "EADBE3F0-F64B-4583-B49D-F0031BBC929F", "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE", @"24" );
 
             var attributeGuid = "A9B39207-F075-4208-B97E-43C8773F706D";
             var attributeValueGuid = "5CC0532F-55A0-4329-A560-ECC6417F49BB";
-            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedNotifications", "Minimum Follow Up Care Touch Hours", "Minimum Follow Up Care Touch Hours", @"Minimum hours for the follow up worker to add a care touch before the Care Touch Needed notification gets sent out.", 0, @"24", attributeGuid, "MinimumFollowUpTouchHours" );
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.ServiceJob", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Class", "rocks.kfs.StepsToCare.Jobs.CareNeedAutomatedProcesses", "Minimum Follow Up Care Touch Hours", "Minimum Follow Up Care Touch Hours", @"Minimum hours for the follow up worker to add a care touch before the Care Touch Needed notification gets sent out.", 0, @"24", attributeGuid, "MinimumFollowUpTouchHours" );
 
             // copied and modified from RockMigrationHelper.AddAttributeValue method to use the value from another attribute.
             Sql( $@"

--- a/rocks.kfs.StepsToCare/Migrations/023_UpdateAttributes.cs
+++ b/rocks.kfs.StepsToCare/Migrations/023_UpdateAttributes.cs
@@ -29,7 +29,7 @@ namespace rocks.kfs.StepsToCare.Migrations
         {
 
             var rockContext = new RockContext();
-            var attributeMatrixTemplateId = new AttributeMatrixTemplateService( rockContext ).Get( SystemGuid.Attribute.CATEGORY_MATRIX_CARE_TOUCHES.AsGuid() ).Id.ToString();
+            var attributeMatrixTemplateId = new AttributeMatrixTemplateService( rockContext ).Get( SystemGuid.Category.MATRIX_CARE_TOUCHES.AsGuid() ).Id.ToString();
 
             var assignToGroupDesc = "If groups are selected for this touch template, \"Minimum Care Touches\" number of people will be assigned in a round-robin fashion for any new Care Need in this category. If multiple groups are chosen, that same number of members from each group will be assigned. ";
 
@@ -65,11 +65,11 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.MATRIX_ATTRIBUTE_ASSIGNTOGROUPS, "repeatDirection", "0", "F1A6D5C2-4021-4BF6-ABC4-CE5A4B04F691" );
             RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.MATRIX_ATTRIBUTE_ASSIGNTOGROUPS, "values", groupSelectSql, "73149EF2-195E-4E8F-87EA-044A0C4E3F80" );
 
-            RockMigrationHelper.AddDefinedTypeAttribute( SystemGuid.DefinedType.CARE_NEED_CATEGORY, Rock.SystemGuid.FieldType.MULTI_SELECT, "Assign to Group(s)", "AssignToGroups", "If groups are selected, one member from each group will be assigned in a round-robin fashion for any new Care Need in this category. ", 3, "", SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS );
-            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS, "enhancedselection", "True", "C299C97E-B3EF-45F4-AA12-924FC9BCADA9" );
-            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS, "repeatColumns", "", "18F97937-8A3C-4099-9F02-491B1ACD684B" );
-            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS, "repeatDirection", "0", "0B1F2E6A-E9E6-479A-8D77-667CD17E1315" );
-            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS, "values", groupSelectSql, "B544C383-CCBA-4D80-B86E-F843F4AF0453" );
+            RockMigrationHelper.AddDefinedTypeAttribute( SystemGuid.DefinedType.CARE_NEED_CATEGORY, Rock.SystemGuid.FieldType.MULTI_SELECT, "Assign to Group(s)", "AssignToGroups", "If groups are selected, one member from each group will be assigned in a round-robin fashion for any new Care Need in this category. ", 3, "", SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS, "enhancedselection", "True", "C299C97E-B3EF-45F4-AA12-924FC9BCADA9" );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS, "repeatColumns", "", "18F97937-8A3C-4099-9F02-491B1ACD684B" );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS, "repeatDirection", "0", "0B1F2E6A-E9E6-479A-8D77-667CD17E1315" );
+            RockMigrationHelper.AddAttributeQualifier( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS, "values", groupSelectSql, "B544C383-CCBA-4D80-B86E-F843F4AF0453" );
 
             RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Minimum Follow Up Care Touch Hours", "MinimumFollowUpTouchHours", "Minimum Follow Up Care Touch Hours", @"Minimum hours for the follow up worker to add a care touch before the need gets 'flagged'.", 4, @"24", "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE" );
             RockMigrationHelper.AddBlockAttributeValue( "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE", "8945BE62-D065-4A19-89A8-B06CE51FFBFF", @"24" );
@@ -115,7 +115,7 @@ namespace rocks.kfs.StepsToCare.Migrations
 
             RockMigrationHelper.DeleteAttribute( "3D5545C1-29AF-4DF4-8C5C-8330651F4FEE" );
 
-            RockMigrationHelper.DeleteAttribute( SystemGuid.Attribute.CATEGORY_ATTRIBUTE_ASSIGNTOGROUPS );
+            RockMigrationHelper.DeleteAttribute( SystemGuid.Category.ATTRIBUTE_ASSIGNTOGROUPS );
 
             RockMigrationHelper.DeleteAttribute( SystemGuid.Attribute.MATRIX_ATTRIBUTE_ASSIGNTOGROUPS );
         }

--- a/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
+++ b/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
@@ -27,8 +27,8 @@ namespace rocks.kfs.StepsToCare.Migrations
     {
         public override void Up()
         {
-            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care - Care Need", "fa fa-hand-holding", "History entries for the plugin Steps to Care Care Need entity.", SystemGuid.Category.HISTORY_CARE_NEED );
-            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care", "fa fa-hand-holding", "History entries for the plugin Steps to Care under Person history (assign workers or other history directly related to a person).", SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE, 0, Rock.SystemGuid.Category.HISTORY_PERSON );
+            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care - Care Need", "fa fa-hand-holding", "Care Need entity history entries for the Steps to Care plugin.", SystemGuid.Category.HISTORY_CARE_NEED );
+            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care", "fa fa-hand-holding", "Person History entries from Steps to Care plugin (assign workers or other history directly related to a person).", SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE, 0, Rock.SystemGuid.Category.HISTORY_PERSON );
             Sql( $@"
                 DECLARE 
                     @AttributeId int,
@@ -96,6 +96,7 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.DeletePage( "653F2B13-E828-4263-B12B-C419A1833197" );
 
             RockMigrationHelper.DeleteAttribute( "9C990D50-769F-4BFD-8AFE-02092C76B68C" );
+            RockMigrationHelper.DeleteAttribute( "69F3EC39-E754-4E94-85F9-3DC2ED6099C4" );
         }
     }
 }

--- a/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
+++ b/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
@@ -29,6 +29,33 @@ namespace rocks.kfs.StepsToCare.Migrations
         {
             RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care - Care Need", "fa fa-hand-holding", "History entries for the plugin Steps to Care Care Need entity.", SystemGuid.Category.HISTORY_CARE_NEED );
             RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care", "fa fa-hand-holding", "History entries for the plugin Steps to Care under Person history (assign workers or other history directly related to a person).", SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE, 0, Rock.SystemGuid.Category.HISTORY_PERSON );
+            Sql( $@"
+                DECLARE 
+                    @AttributeId int,
+                    @EntityId int
+
+                SET @AttributeId = (SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '0C405062-72BB-4362-9738-90C9ED5ACDDE')
+                SET @EntityId = (SELECT TOP 1 [ID] FROM [Category] where [Guid] = '{SystemGuid.Category.HISTORY_CARE_NEED}')
+
+                DELETE FROM [AttributeValue] WHERE [Guid] = 'B825A151-9DF6-473A-AA56-B7714AA58900'
+
+                INSERT INTO [AttributeValue] ([IsSystem],[AttributeId],[EntityId],[Value],[Guid])
+                VALUES(
+                    1,@AttributeId,@EntityId,'~/StepsToCareDetail/{{0}}','B825A151-9DF6-473A-AA56-B7714AA58900')" );
+
+            Sql( $@"
+                DECLARE 
+                    @AttributeId int,
+                    @EntityId int
+
+                SET @AttributeId = (SELECT TOP 1 [Id] FROM [Attribute] WHERE [Guid] = '0C405062-72BB-4362-9738-90C9ED5ACDDE')
+                SET @EntityId = (SELECT TOP 1 [ID] FROM [Category] where [Guid] = '{SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE}')
+
+                DELETE FROM [AttributeValue] WHERE [Guid] = '34C7CE36-192E-4BE9-A895-220B99AA09F6'
+
+                INSERT INTO [AttributeValue] ([IsSystem],[AttributeId],[EntityId],[Value],[Guid])
+                VALUES(
+                    1,@AttributeId,@EntityId,'~/StepsToCareDetail/{{0}}','34C7CE36-192E-4BE9-A895-220B99AA09F6')" );
 
             RockMigrationHelper.AddPage( true, "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "D65F783D-87A9-4CC9-8110-E83466A0EADB", "Care Need History", "", "653F2B13-E828-4263-B12B-C419A1833197" );
             RockMigrationHelper.AddBlock( "653F2B13-E828-4263-B12B-C419A1833197", "", "C6C2DF41-A50D-4975-B21C-4EFD6FF3E8D0", "History Log", "Main", "", "", 0, "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F" );
@@ -43,8 +70,19 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.UpdatePageContext( "653F2B13-E828-4263-B12B-C419A1833197", "rocks.kfs.StepsToCare.Model.CareNeed", "CareNeedId", "81EE561B-C87F-46DE-AAF4-8B6476E2AA79" );
             RockMigrationHelper.AddOrUpdatePageRoute( "653F2B13-E828-4263-B12B-C419A1833197", "StepsToCareDetail/{CareNeedId}/History", "73EDDBA6-737D-423F-B513-6E08113DA346" );
 
+            // Attribute for  BlockType
+            //   BlockType: Care Entry
+            //   Category: KFS > Steps To Care
+            //   Attribute: Care Need History Page
             RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "BD53F9C9-EBA9-4D3F-82EA-DE5DD34A8108", "Care Need History Page", "CareNeedHistoryPage", "Care Need History Page", @"Page used to display history details.", 0, @"", "9C990D50-769F-4BFD-8AFE-02092C76B68C" );
             RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "9C990D50-769F-4BFD-8AFE-02092C76B68C", @"653f2b13-e828-4263-b12b-c419a1833197,73eddba6-737d-423f-b513-6e08113da346" );
+
+            // Attribute for  BlockType
+            //   BlockType: Care Dashboard
+            //   Category: KFS > Steps To Care
+            //   Attribute: Care Need History Page
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "AF14CB6C-F915-4449-9CB7-7C44B624B051", "BD53F9C9-EBA9-4D3F-82EA-DE5DD34A8108", "Care Need History Page", "CareNeedHistoryPage", "Care Need History Page", @"Page used to view history of Care Needs (if not set the action will not show)", 11, @"", "69F3EC39-E754-4E94-85F9-3DC2ED6099C4" );
+            RockMigrationHelper.AddBlockAttributeValue( "EADBE3F0-F64B-4583-B49D-F0031BBC929F", "69F3EC39-E754-4E94-85F9-3DC2ED6099C4", @"653f2b13-e828-4263-b12b-c419a1833197,73eddba6-737d-423f-b513-6e08113da346" );
         }
 
         public override void Down()

--- a/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
+++ b/rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
@@ -1,0 +1,63 @@
+﻿// <copyright>
+// Copyright 2025 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 24, "1.16.0" )]
+    public class AddHistory : Migration
+    {
+        public override void Up()
+        {
+            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care - Care Need", "fa fa-hand-holding", "History entries for the plugin Steps to Care Care Need entity.", SystemGuid.Category.HISTORY_CARE_NEED );
+            RockMigrationHelper.UpdateCategory( Rock.SystemGuid.EntityType.HISTORY, "Steps to Care", "fa fa-hand-holding", "History entries for the plugin Steps to Care under Person history (assign workers or other history directly related to a person).", SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE, 0, Rock.SystemGuid.Category.HISTORY_PERSON );
+
+            RockMigrationHelper.AddPage( true, "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "D65F783D-87A9-4CC9-8110-E83466A0EADB", "Care Need History", "", "653F2B13-E828-4263-B12B-C419A1833197" );
+            RockMigrationHelper.AddBlock( "653F2B13-E828-4263-B12B-C419A1833197", "", "C6C2DF41-A50D-4975-B21C-4EFD6FF3E8D0", "History Log", "Main", "", "", 0, "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F" );
+
+            //   Attribute: Heading
+            RockMigrationHelper.AddBlockAttributeValue( "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F", "EAAE646D-69CD-41AC-9B8A-7EC5A446B379", @"{{ Entity.EntityStringValue }} (ID:{{ Entity.Id }})" );
+            //   Attribute: Entity Type
+            RockMigrationHelper.AddBlockAttributeValue( "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F", "E9BB2534-D54E-4D50-A241-FCD45EFADE32", @"87ac878d-6740-43eb-9389-b8440ac595c3" );
+            //   Attribute: Category
+            RockMigrationHelper.AddBlockAttributeValue( "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F", "44092D4B-213D-4572-A005-C2B35E0B4082", @"4c4b37d6-6966-4864-ab06-ff92ece501bb" );
+
+            RockMigrationHelper.UpdatePageContext( "653F2B13-E828-4263-B12B-C419A1833197", "rocks.kfs.StepsToCare.Model.CareNeed", "CareNeedId", "81EE561B-C87F-46DE-AAF4-8B6476E2AA79" );
+            RockMigrationHelper.AddOrUpdatePageRoute( "653F2B13-E828-4263-B12B-C419A1833197", "StepsToCareDetail/{CareNeedId}/History", "73EDDBA6-737D-423F-B513-6E08113DA346" );
+
+            RockMigrationHelper.AddOrUpdateBlockTypeAttribute( "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE", "BD53F9C9-EBA9-4D3F-82EA-DE5DD34A8108", "Care Need History Page", "CareNeedHistoryPage", "Care Need History Page", @"Page used to display history details.", 0, @"", "9C990D50-769F-4BFD-8AFE-02092C76B68C" );
+            RockMigrationHelper.AddBlockAttributeValue( "F953C5EF-6504-45F9-81A8-063518B7AB61", "9C990D50-769F-4BFD-8AFE-02092C76B68C", @"653f2b13-e828-4263-b12b-c419a1833197,73eddba6-737d-423f-b513-6e08113da346" );
+        }
+
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteCategory( SystemGuid.Category.HISTORY_CARE_NEED );
+            RockMigrationHelper.DeleteCategory( SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE );
+
+            RockMigrationHelper.DeletePageContext( "81EE561B-C87F-46DE-AAF4-8B6476E2AA79" );
+            RockMigrationHelper.DeletePageRoute( "73EDDBA6-737D-423F-B513-6E08113DA346" );
+            RockMigrationHelper.DeleteBlock( "C5E4F1D7-0B2A-4F3C-8D6E-9B5A0F1D7E3F" );
+            RockMigrationHelper.DeletePage( "653F2B13-E828-4263-B12B-C419A1833197" );
+
+            RockMigrationHelper.DeleteAttribute( "9C990D50-769F-4BFD-8AFE-02092C76B68C" );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2024 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.0.3.*" )]
+[assembly: AssemblyVersion( "2.1.0.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/SystemGuid/Category.cs
+++ b/rocks.kfs.StepsToCare/SystemGuid/Category.cs
@@ -14,18 +14,21 @@
 // limitations under the License.
 // </copyright>
 //
+using System.Runtime.InteropServices;
+
 namespace rocks.kfs.StepsToCare.SystemGuid
 {
     /// <summary>
-    /// Custom KFS Attributes for Steps to Care plugin
+    /// Custom KFS Categories for Steps to Care plugin
     /// </summary>
-    public class Attribute
+    public class Category
     {
-        public const string MATRIX_ATTRIBUTE_TOUCH_NOTE_TEMPLATE = "B0E43BE0-223E-4135-9A10-E75EA7995048";
-        public const string MATRIX_ATTRIBUTE_TOUCH_MINIMUM_TOUCHES = "15900A01-A407-47BC-A770-BF1E620AA7FF";
-        public const string MATRIX_ATTRIBUTE_TOUCH_MINIMUM_HOURS = "40433C65-E693-48CB-85FE-A2F54E8511B5";
-        public const string MATRIX_ATTRIBUTE_TOUCH_NOTIFY_ALL = "C6AD82BE-C51A-48E7-B0AC-DA87EC8DA775";
-        public const string MATRIX_ATTRIBUTE_TOUCH_RECURRING = "E595A2F7-5FF5-42F3-8AAF-9BF5BB154BF4";
-        public const string MATRIX_ATTRIBUTE_ASSIGNTOGROUPS = "2BC5F3D1-C9B1-4CD1-91DD-DB0B0651C502";
+        /// <summary>
+        /// The Care Need category guids.
+        /// </summary>
+        public const string MATRIX_CARE_TOUCHES = "CE6B7E82-05BB-443A-B277-AE15165D9310";
+        public const string ATTRIBUTE_ASSIGNTOGROUPS = "182FDE86-05B4-44E1-BD4E-B570AA639B40";
+        public const string HISTORY_CARE_NEED = "4C4B37D6-6966-4864-AB06-FF92ECE501BB";
+        public const string HISTORY_PERSON_STEPS_TO_CARE = "653F2B13-E828-4263-B12B-C419A1833197";
     }
 }

--- a/rocks.kfs.StepsToCare/SystemGuid/Category.cs
+++ b/rocks.kfs.StepsToCare/SystemGuid/Category.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2024 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2024 by Kingdom First Solutions
+// Copyright 2025 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -804,6 +804,11 @@ namespace rocks.kfs.StepsToCare
         public static DefinedValue DefinedValueFromCache( string definedValueGuid )
         {
             var definedValueCache = DefinedValueCache.Get( definedValueGuid );
+
+            if ( definedValueCache == null )
+            {
+                return new DefinedValue();
+            }
             var definedValue = new DefinedValue
             {
                 Id = definedValueCache.Id,
@@ -819,7 +824,7 @@ namespace rocks.kfs.StepsToCare
         public static DefinedValue DefinedValueFromCache( int? definedValueId )
         {
             var definedValueCache = DefinedValueCache.Get( definedValueId ?? 0 );
-            return DefinedValueFromCache( definedValueCache.Guid.ToString() );
+            return DefinedValueFromCache( definedValueCache?.Guid.ToString() );
         }
 
         private static PageReference GetParentPage( int pageId )

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -44,6 +44,7 @@ namespace rocks.kfs.StepsToCare
             var careNeedService = new CareNeedService( rockContext );
             var careWorkerService = new CareWorkerService( rockContext );
             var careAssigneeService = new AssignedPersonService( rockContext );
+            var careNeedHistory = new History.HistoryChangeList();
 
             // reload careNeed to fully populate child properties
             if ( !previewAssigned )
@@ -94,6 +95,10 @@ namespace rocks.kfs.StepsToCare
 
                             assignedPeople.Add( careAssignee );
                             addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+
+                            string newStringValue = History.GetValue<PersonAlias>( worker.PersonAlias, worker.PersonAliasId, rockContext, "" );
+                            careNeedHistory.AddChange( History.HistoryVerb.Add, History.HistoryChangeType.Record, "Assign Person", null, newStringValue ).SourceOfChange = "Geofence Assignment";
+                            AddPersonHistory( rockContext, careNeed, careNeed.PersonAlias.Person, worker.PersonAlias, "ASSIGNED", "Geofence Assignment" );
                         }
                     }
                     else if ( homeLocation != null && homeLocation.GeoPoint == null )
@@ -378,6 +383,11 @@ namespace rocks.kfs.StepsToCare
                         assignedPeople.Add( careAssignee );
                         addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
 
+                        string sourceOfChange = $"Worker Assignment [Count: {workerCount.Count}]";
+                        string newStringValue = History.GetValue<PersonAlias>( worker.PersonAlias, worker.PersonAliasId, rockContext, "" );
+                        careNeedHistory.AddChange( History.HistoryVerb.Add, History.HistoryChangeType.Record, "Assign Person", null, newStringValue ).SourceOfChange = sourceOfChange;
+                        AddPersonHistory( rockContext, careNeed, careNeed.PersonAlias.Person, worker.PersonAlias, "ASSIGNED", sourceOfChange );
+
                         workerAssigned = true;
 
                         if ( enableLogging )
@@ -422,6 +432,11 @@ namespace rocks.kfs.StepsToCare
 
                                 assignedPeople.Add( careAssignee );
                                 addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+
+                                string sourceOfChange = $"Group Role Assignment - {member.Group.GroupType.Name} > {member.Group.Name} [{member.GroupId}] > {member.GroupRole.Name}";
+                                string newStringValue = History.GetValue<PersonAlias>( member.Person.PrimaryAlias, member.Person.PrimaryAliasId, rockContext, "" );
+                                careNeedHistory.AddChange( History.HistoryVerb.Add, History.HistoryChangeType.Record, "Assign Person", null, newStringValue ).SourceOfChange = sourceOfChange;
+                                AddPersonHistory( rockContext, careNeed, careNeed.PersonAlias.Person, member.Person.PrimaryAlias, "ASSIGNED", sourceOfChange );
                             }
                         }
                         if ( enableLogging )
@@ -482,7 +497,7 @@ namespace rocks.kfs.StepsToCare
                 {
                     foreach ( var groupId in categoryGroups )
                     {
-                        AssignToGroupMember( careNeed, enableLogging, assignedPeople, rockContext, careAssigneeService, addedWorkerAliasIds, closedStatusId, groupId, currentlyAssignedPeople );
+                        AssignToGroupMember( careNeed, enableLogging, assignedPeople, rockContext, careAssigneeService, addedWorkerAliasIds, closedStatusId, groupId, currentlyAssignedPeople, careNeedHistory: careNeedHistory );
                     }
                 }
 
@@ -492,7 +507,7 @@ namespace rocks.kfs.StepsToCare
                     {
                         foreach ( var groupId in touchTemplate.AssignToGroups )
                         {
-                            AssignToGroupMember( careNeed, enableLogging, assignedPeople, rockContext, careAssigneeService, addedWorkerAliasIds, closedStatusId, groupId, currentlyAssignedPeople, touchTemplate );
+                            AssignToGroupMember( careNeed, enableLogging, assignedPeople, rockContext, careAssigneeService, addedWorkerAliasIds, closedStatusId, groupId, currentlyAssignedPeople, touchTemplate, careNeedHistory: careNeedHistory );
                         }
                     }
                 }
@@ -501,13 +516,36 @@ namespace rocks.kfs.StepsToCare
             if ( !previewAssigned )
             {
                 careAssigneeService.AddRange( assignedPeople );
-                rockContext.SaveChanges();
+                rockContext.WrapTransaction( () =>
+                {
+                    if ( rockContext.SaveChanges() > 0 )
+                    {
+                        if ( careNeedHistory.Any() )
+                        {
+                            HistoryService.SaveChanges(
+                                rockContext,
+                                typeof( CareNeed ),
+                                SystemGuid.Category.HISTORY_CARE_NEED.AsGuid(),
+                                careNeed.Id,
+                                careNeedHistory,
+                                "Auto Assign People",
+                                null,
+                                null
+                            );
+                        }
+                    }
+                } );
             }
             return assignedPeople;
         }
 
-        private static void AssignToGroupMember( CareNeed careNeed, bool enableLogging, List<AssignedPerson> assignedPeople, RockContext rockContext, AssignedPersonService careAssigneeService, List<int?> addedWorkerAliasIds, int closedStatusId, int groupId, IQueryable<AssignedPerson> currentlyAssignedPeople, TouchTemplate touchTemplate = null )
+        private static void AssignToGroupMember( CareNeed careNeed, bool enableLogging, List<AssignedPerson> assignedPeople, RockContext rockContext, AssignedPersonService careAssigneeService, List<int?> addedWorkerAliasIds, int closedStatusId, int groupId, IQueryable<AssignedPerson> currentlyAssignedPeople, TouchTemplate touchTemplate = null, History.HistoryChangeList careNeedHistory = null )
         {
+            if ( careNeedHistory == null )
+            {
+                careNeedHistory = new History.HistoryChangeList();
+            }
+
             var groupMemberService = new GroupMemberService( rockContext );
 
             var groupMembers = groupMemberService
@@ -524,6 +562,7 @@ namespace rocks.kfs.StepsToCare
             {
                 if ( !addedWorkerAliasIds.Contains( gm.Person.PrimaryAliasId ) && gm.Person.PrimaryAlias != null && gm.Person.PrimaryAliasId != careNeed.PersonAliasId && careAssigneeService.GetByPersonAliasAndCareNeed( gm.Person.PrimaryAlias.Id, careNeed.Id ) == null )
                 {
+                    var sourceOfChange = "";
                     var careAssignee = new AssignedPerson { Id = 0 };
                     careAssignee.CareNeed = careNeed;
                     careAssignee.PersonAliasId = gm.Person.PrimaryAliasId;
@@ -533,15 +572,21 @@ namespace rocks.kfs.StepsToCare
                         careAssignee.Type = AssignedType.TouchTemplateGroup;
                         careAssignee.TypeQualifier = $"{touchTemplate.NoteTemplate.Note}^{touchTemplate.MinimumCareTouches}^{gm.Group.Id}^{gm.Group.Name}^{gm.Id}^{currentlyAssignedPeople.Count( ap => ap.PersonAlias.PersonId == gm.Person.Id )}^{touchTemplate.MinimumCareTouchHours}";
                         // This TypeQualifier could have a tighter connection to the attribute matrix touch template if we somehow identified the touch template, such as using an attribute or attribute value id.
+                        sourceOfChange = $"Touch Template Assignment - {touchTemplate.NoteTemplate.Note} ({gm.Group.Name} [{gm.GroupId}])";
                     }
                     else
                     {
                         careAssignee.Type = AssignedType.CategoryGroup;
                         careAssignee.TypeQualifier = $"{careNeed.CategoryValueId}^{careNeed.Category?.Value ?? DefinedValueCache.Get( careNeed.CategoryValueId.Value ).Value}^{gm.Group.Id}^{gm.Group.Name}^{gm.Id}^{currentlyAssignedPeople.Count( ap => ap.PersonAlias.PersonId == gm.Person.Id )}";
+                        sourceOfChange = $"Category Assignment - {careNeed.Category?.Value ?? DefinedValueCache.Get( careNeed.CategoryValueId.Value ).Value} ({gm.Group.Name} [{gm.GroupId}])";
 
                     }
                     assignedPeople.Add( careAssignee );
                     addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
+
+                    string newStringValue = History.GetValue<PersonAlias>( gm.Person.PrimaryAlias, gm.Person.PrimaryAliasId, rockContext, "" );
+                    careNeedHistory.AddChange( History.HistoryVerb.Add, History.HistoryChangeType.Record, "Assign Person", null, newStringValue ).SourceOfChange = sourceOfChange;
+                    AddPersonHistory( rockContext, careNeed, careNeed.PersonAlias.Person, gm.Person.PrimaryAlias, "ASSIGNED", sourceOfChange );
 
                     groupMemberAssignedCount++;
                     if ( touchTemplate == null || groupMemberAssignedCount >= touchTemplate.MinimumCareTouches )
@@ -734,6 +779,26 @@ namespace rocks.kfs.StepsToCare
                                     .ThenBy( cw => cw.LastAssignmentDate )
                                     .ThenBy( cw => cw.Worker.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) )
                                     .ThenBy( cw => cw.Worker.Campuses.Contains( careNeed.CampusId.ToString() ) );
+        }
+
+
+        public static void AddPersonHistory( RockContext rockContext, CareNeed careNeed, Person person, PersonAlias assignedPersonAlias, string historyVerb, string sourceOfChange = null, bool commitSave = false )
+        {
+            var assignedPersonHistory = new History.HistoryChangeList();
+            assignedPersonHistory.AddCustom( historyVerb, "Record", $"{assignedPersonAlias.Person.FullName} [{assignedPersonAlias.PersonId}]</span> {( ( historyVerb == "ASSIGNED" ) ? "to" : "from" )} Care Need [{careNeed.Id}] for <span class='field-value'>{person.FullName}</span><span class='field-value'>" ).SourceOfChange = sourceOfChange;
+            if ( assignedPersonHistory.Any() )
+            {
+                HistoryService.SaveChanges(
+                    rockContext,
+                    typeof( Person ),
+                    SystemGuid.Category.HISTORY_PERSON_STEPS_TO_CARE.AsGuid(),
+                    assignedPersonAlias.PersonId,
+                    assignedPersonHistory,
+                    $"Care Need for {person.FullName}",
+                    typeof( CareNeed ),
+                    careNeed.Id,
+                    commitSave );
+            }
         }
 
         private static PageReference GetParentPage( int pageId )

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -801,6 +801,27 @@ namespace rocks.kfs.StepsToCare
             }
         }
 
+        public static DefinedValue DefinedValueFromCache( string definedValueGuid )
+        {
+            var definedValueCache = DefinedValueCache.Get( definedValueGuid );
+            var definedValue = new DefinedValue()
+            {
+                Id = definedValueCache.Id,
+                Guid = definedValueCache.Guid,
+                Value = definedValueCache.Value,
+                Description = definedValueCache.Description,
+                Order = definedValueCache.Order,
+                IsActive = definedValueCache.IsActive
+            };
+            return definedValue;
+        }
+
+        public static DefinedValue DefinedValueFromCache( int? definedValueId )
+        {
+            var definedValueCache = DefinedValueCache.Get( definedValueId ?? 0 );
+            return DefinedValueFromCache( definedValueCache.Guid.ToString() );
+        }
+
         private static PageReference GetParentPage( int pageId )
         {
             var pageCache = PageCache.Get( pageId );

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -804,7 +804,7 @@ namespace rocks.kfs.StepsToCare
         public static DefinedValue DefinedValueFromCache( string definedValueGuid )
         {
             var definedValueCache = DefinedValueCache.Get( definedValueGuid );
-            var definedValue = new DefinedValue()
+            var definedValue = new DefinedValue
             {
                 Id = definedValueCache.Id,
                 Guid = definedValueCache.Guid,

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Migrations\021_DefaultValue.cs" />
     <Compile Include="Migrations\020_NewCommunications.cs" />
     <Compile Include="Migrations\019_AddFieldTypeAndAttributeMatrix.cs" />
+    <Compile Include="Migrations\024_AddHistory.cs" />
     <Compile Include="Migrations\023_UpdateAttributes.cs" />
     <Compile Include="Migrations\018_AddDefinedValueAndProperty.cs" />
     <Compile Include="Migrations\017_AddColumn.cs" />

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Model\TouchTemplate.cs" />
     <Compile Include="Model\WorkerResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemGuid\Category.cs" />
     <Compile Include="SystemGuid\FieldType.cs" />
     <Compile Include="SystemGuid\Attribute.cs" />
     <Compile Include="Utilities.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Migrations and Guids for use with Steps to Care History changes in https://github.com/KingdomFirst/RockBlocks/pull/201
- Added History when a need is auto assigned

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added History to Steps to Care when workers are assigned.

---------

### Requested By

##### Who reported, requested, or paid for the change?

ADA

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
- rocks.kfs.StepsToCare/SystemGuid/Category.cs
- rocks.kfs.StepsToCare/SystemGuid/Attribute.cs
- rocks.kfs.StepsToCare/Migrations/024_AddHistory.cs
- rocks.kfs.StepsToCare/Migrations/023_UpdateAttributes.cs
- rocks.kfs.StepsToCare/Migrations/019_AddFieldTypeAndAttributeMatrix.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

https://github.com/KingdomFirst/RockBlocks/pull/201
