### PR TITLE
Steps to Care Fixes

### DIFF
--- a/rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs
+++ b/rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs
@@ -34,13 +34,13 @@ namespace rocks.kfs.StepsToCare.Migrations
             RockMigrationHelper.AddPage( true, "1F93E9AA-ECCA-42A2-8C91-73D991DBCD9F", "D65F783D-87A9-4CC9-8110-E83466A0EADB", "Care Configuration", "", "39F72E9D-22B7-4F1E-8633-6C3745AC6F34", "" );
 
             // Add Page Route for Steps to Care
-            RockMigrationHelper.AddPageRoute( "1F93E9AA-ECCA-42A2-8C91-73D991DBCD9F", "StepsToCare", "9FA7606C-13BC-4049-A1A1-0389C98C3743" );
+            RockMigrationHelper.AddOrUpdatePageRoute( "1F93E9AA-ECCA-42A2-8C91-73D991DBCD9F", "StepsToCare", "9FA7606C-13BC-4049-A1A1-0389C98C3743" );
 
             // Add Page Route for Care Entry
-            RockMigrationHelper.AddPageRoute( "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "StepsToCareDetail", "7DA0C653-88E4-4997-89BA-C58B33A2AA32" );
+            RockMigrationHelper.AddOrUpdatePageRoute( "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "StepsToCareDetail", "7DA0C653-88E4-4997-89BA-C58B33A2AA32" );
 
             // Add Page Route for Care Entry
-            RockMigrationHelper.AddPageRoute( "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "StepsToCareDetail/{CareNeedId}", "32CDFBC1-F3EB-405B-9462-F7E2DD722006" );
+            RockMigrationHelper.AddOrUpdatePageRoute( "27953B65-21E2-4CA9-8461-3AFAD46D9BC8", "StepsToCareDetail/{CareNeedId}", "32CDFBC1-F3EB-405B-9462-F7E2DD722006" );
 
             // Add/Update BlockType Care Entry
             RockMigrationHelper.UpdateBlockType( "Care Entry", "Care entry page for KFS Steps to Care package. Used for adding and editing care needs ", "~/Plugins/rocks_kfs/StepsToCare/CareEntry.ascx", "KFS > Steps To Care", "4F0F9ED7-9F74-4152-B27F-D9B2A458AFBE" );

--- a/rocks.kfs.StepsToCare/Migrations/014_NewPageAndAttributes.cs
+++ b/rocks.kfs.StepsToCare/Migrations/014_NewPageAndAttributes.cs
@@ -56,7 +56,7 @@ namespace rocks.kfs.StepsToCare.Migrations
             // Add Page Route
             //   Page:Care Needs
             //   Route:Person/{PersonId}/CareNeeds
-            RockMigrationHelper.AddPageRoute( "ABA4CE73-28DC-42DE-BE70-33F09287C116", "Person/{PersonId}/CareNeeds", "A243DDEE-1B40-4DAD-8A70-35116558E47F" );
+            RockMigrationHelper.AddOrUpdatePageRoute( "ABA4CE73-28DC-42DE-BE70-33F09287C116", "Person/{PersonId}/CareNeeds", "A243DDEE-1B40-4DAD-8A70-35116558E47F" );
             // Add Block
             //  Block Name: Care Dashboard
             //  Page Name: Care Needs

--- a/rocks.kfs.StepsToCare/Migrations/017_AddColumn.cs
+++ b/rocks.kfs.StepsToCare/Migrations/017_AddColumn.cs
@@ -36,10 +36,10 @@ namespace rocks.kfs.StepsToCare.Migrations
                 BEGIN
                 INSERT [_rocks_kfs_StepsToCare_NoteTemplate] ([Icon], [Note], [IsActive], [Order], [Guid], [CreatedDateTime], [ModifiedDateTime])
                 VALUES
-                (N'fas fa-phone-square', N'Called', 1, 0, NEWID(), GETDATE(), GETDATE())
-                ,(N'far fa-comment', N'Text Message Sent', 1, 1, NEWID(), GETDATE(), GETDATE())
+                (N'fa fa-phone-square', N'Called', 1, 0, NEWID(), GETDATE(), GETDATE())
+                ,(N'fa fa-comment', N'Text Message Sent', 1, 1, NEWID(), GETDATE(), GETDATE())
                 ,(N'fa fa-envelope', N'Mail Sent', 1, 2, NEWID(), GETDATE(), GETDATE())
-                ,(N'fas fa-gift', N'Gift Given', 1, 3, NEWID(), GETDATE(), GETDATE())
+                ,(N'fa fa-gift', N'Gift Given', 1, 3, NEWID(), GETDATE(), GETDATE())
                 ,(N'fa fa-car', N'Visited', 1, 4, NEWID(), GETDATE(), GETDATE())
                 END" );
         }

--- a/rocks.kfs.StepsToCare/Migrations/025_FixNoteTemplate.cs
+++ b/rocks.kfs.StepsToCare/Migrations/025_FixNoteTemplate.cs
@@ -1,0 +1,34 @@
+﻿// <copyright>
+// Copyright 2026 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace rocks.kfs.StepsToCare.Migrations
+{
+    [MigrationNumber( 25, "1.16.0" )]
+    public class FixNoteTemplate : Migration
+    {
+        public override void Up()
+        {
+            Sql( $@"UPDATE _rocks_kfs_StepsToCare_NoteTemplate SET Icon = 'fa fa-comment' WHERE Icon = 'far fa-comment'" );
+        }
+
+        public override void Down()
+        {
+            Sql( $@"UPDATE _rocks_kfs_StepsToCare_NoteTemplate SET Icon = 'far fa-comment' WHERE Icon = 'fa fa-comment'" );
+        }
+    }
+}

--- a/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2025 by Kingdom First Solutions
+// Copyright 2026 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.StepsToCare" )]
 [assembly: AssemblyProduct( "rocks.kfs.StepsToCare" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2026" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.1.0.*" )]
+[assembly: AssemblyVersion( "2.1.1.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -20,7 +20,9 @@ using System.Data.Entity;
 using System.Linq;
 using System.Text;
 using System.Web;
-using NuGet;
+
+using Microsoft.Extensions.Logging;
+
 using Rock;
 using Rock.Communication;
 using Rock.Data;
@@ -29,10 +31,12 @@ using Rock.Model;
 using Rock.Web;
 using Rock.Web.Cache;
 using Rock.Web.UI;
+
 using rocks.kfs.StepsToCare.Model;
 
 namespace rocks.kfs.StepsToCare
 {
+    [RockLoggingCategory]
     public class CareUtilities
     {
         public static List<AssignedPerson> AutoAssignWorkers( CareNeed careNeed, bool roundRobinOnly = false, bool childAssignment = false, bool autoAssignWorker = false, bool autoAssignWorkerGeofence = false, string loadBalanceType = "Exclusive", List<Guid> leaderRoleGuids = null, bool enableLogging = false, bool previewAssigned = false )
@@ -609,6 +613,8 @@ namespace rocks.kfs.StepsToCare
                 rockContext = new RockContext();
             }
 
+            var logger = RockLogger.LoggerFactory.CreateLogger<CareUtilities>();
+
             var assignedPersons = careNeed.AssignedPersons;
             if ( newlyAssignedPersons.Any() && !isNew )
             {
@@ -623,7 +629,10 @@ namespace rocks.kfs.StepsToCare
                 {
                     foreach ( var need in careNeed.ChildNeeds )
                     {
-                        assignedPersons.AddRange( need.AssignedPersons );
+                        foreach ( var ap in need.AssignedPersons )
+                        {
+                            assignedPersons.Add( ap );
+                        }
                     }
                 }
             }
@@ -650,10 +659,6 @@ namespace rocks.kfs.StepsToCare
                 {
                     assignee.PersonAlias.Person.LoadAttributes();
                     var smsNumber = assignee.PersonAlias.Person.PhoneNumbers.GetFirstSmsNumber();
-                    if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) && smsNumber.IsNullOrWhiteSpace() )
-                    {
-                        continue;
-                    }
 
                     var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( rockPage, ( rockPage != null ) ? rockPage.CurrentPerson : person );
                     mergeFields.Add( "CareNeed", careNeed );
@@ -669,7 +674,7 @@ namespace rocks.kfs.StepsToCare
                         if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) )
                         {
                             var emailWarningMessage = string.Format( "{0} does not have a valid email address.", assignee.PersonAlias.Person.FullName );
-                            RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", emailWarningMessage );
+                            logger.LogWarning( emailWarningMessage );
                             errors.Add( emailWarningMessage );
                         }
                         else
@@ -683,7 +688,7 @@ namespace rocks.kfs.StepsToCare
                         if ( string.IsNullOrWhiteSpace( smsNumber ) )
                         {
                             var smsWarningMessage = string.Format( "No SMS number could be found for {0}.", assignee.PersonAlias.Person.FullName );
-                            RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", smsWarningMessage );
+                            logger.LogWarning( smsWarningMessage );
                             errorsSms.Add( smsWarningMessage );
                         }
 
@@ -847,6 +852,9 @@ namespace rocks.kfs.StepsToCare
             {
                 rockContext = new RockContext();
             }
+
+            var logger = RockLogger.LoggerFactory.CreateLogger<CareUtilities>();
+            logger.LogInformation( "Steps To Care - {Type}: {Input} - {Result}", type, input, result );
 
             var rockLogger = new ServiceLogService( rockContext );
             ServiceLog serviceLog = new ServiceLog

--- a/rocks.kfs.StepsToCare/Utilities.cs
+++ b/rocks.kfs.StepsToCare/Utilities.cs
@@ -20,9 +20,6 @@ using System.Data.Entity;
 using System.Linq;
 using System.Text;
 using System.Web;
-
-using Microsoft.Extensions.Logging;
-
 using Rock;
 using Rock.Communication;
 using Rock.Data;
@@ -36,7 +33,6 @@ using rocks.kfs.StepsToCare.Model;
 
 namespace rocks.kfs.StepsToCare
 {
-    [RockLoggingCategory]
     public class CareUtilities
     {
         public static List<AssignedPerson> AutoAssignWorkers( CareNeed careNeed, bool roundRobinOnly = false, bool childAssignment = false, bool autoAssignWorker = false, bool autoAssignWorkerGeofence = false, string loadBalanceType = "Exclusive", List<Guid> leaderRoleGuids = null, bool enableLogging = false, bool previewAssigned = false )
@@ -613,8 +609,6 @@ namespace rocks.kfs.StepsToCare
                 rockContext = new RockContext();
             }
 
-            var logger = RockLogger.LoggerFactory.CreateLogger<CareUtilities>();
-
             var assignedPersons = careNeed.AssignedPersons;
             if ( newlyAssignedPersons.Any() && !isNew )
             {
@@ -674,7 +668,7 @@ namespace rocks.kfs.StepsToCare
                         if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) )
                         {
                             var emailWarningMessage = string.Format( "{0} does not have a valid email address.", assignee.PersonAlias.Person.FullName );
-                            logger.LogWarning( emailWarningMessage );
+                            RockLogger.Log.Warning( emailWarningMessage );
                             errors.Add( emailWarningMessage );
                         }
                         else
@@ -688,7 +682,7 @@ namespace rocks.kfs.StepsToCare
                         if ( string.IsNullOrWhiteSpace( smsNumber ) )
                         {
                             var smsWarningMessage = string.Format( "No SMS number could be found for {0}.", assignee.PersonAlias.Person.FullName );
-                            logger.LogWarning( smsWarningMessage );
+                            RockLogger.Log.Warning( smsWarningMessage );
                             errorsSms.Add( smsWarningMessage );
                         }
 
@@ -852,9 +846,6 @@ namespace rocks.kfs.StepsToCare
             {
                 rockContext = new RockContext();
             }
-
-            var logger = RockLogger.LoggerFactory.CreateLogger<CareUtilities>();
-            logger.LogInformation( "Steps To Care - {Type}: {Input} - {Result}", type, input, result );
 
             var rockLogger = new ServiceLogService( rockContext );
             ServiceLog serviceLog = new ServiceLog

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -45,14 +45,6 @@
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions">
       <HintPath>..\..\RockWeb\Bin\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=9.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\RockWeb\Bin\Microsoft.Extensions.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\RockWeb\Bin\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-    </Reference>
     <Reference Include="Quartz">
       <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
     </Reference>

--- a/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
+++ b/rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
@@ -45,9 +45,13 @@
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions">
       <HintPath>..\..\RockWeb\Bin\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Extensions.Logging, Version=9.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\RockWeb\Bin\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\RockWeb\Bin\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\RockWeb\Bin\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Quartz">
       <HintPath>..\..\RockWeb\Bin\Quartz.dll</HintPath>
@@ -86,6 +90,7 @@
     <Compile Include="Migrations\021_DefaultValue.cs" />
     <Compile Include="Migrations\020_NewCommunications.cs" />
     <Compile Include="Migrations\019_AddFieldTypeAndAttributeMatrix.cs" />
+    <Compile Include="Migrations\025_FixNoteTemplate.cs" />
     <Compile Include="Migrations\024_AddHistory.cs" />
     <Compile Include="Migrations\023_UpdateAttributes.cs" />
     <Compile Include="Migrations\018_AddDefinedValueAndProperty.cs" />


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Remove Nuget using due to nuget disappearing in later versions of Rock. 
- Cleanup some v16+ methods. 
- Including updating logging. 
- And update an icon class that disappears in 18 for some reason.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Miscellaneous fixes.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- rocks.kfs.StepsToCare/rocks.kfs.StepsToCare.csproj
- rocks.kfs.StepsToCare/Utilities.cs
- rocks.kfs.StepsToCare/Properties/AssemblyInfo.cs
- rocks.kfs.StepsToCare/Migrations/025_FixNoteTemplate.cs
- rocks.kfs.StepsToCare/Migrations/017_AddColumn.cs
- rocks.kfs.StepsToCare/Migrations/014_NewPageAndAttributes.cs
- rocks.kfs.StepsToCare/Migrations/004_CreatePages.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No