### PR TITLE
Reach v1 to v2 in API

### DIFF
--- a/rocks.kfs.Reach/Gateway.cs
+++ b/rocks.kfs.Reach/Gateway.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2026 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ namespace rocks.kfs.Reach
     public class Gateway : GatewayComponent
     {
         private readonly string DemoUrl = "demo.reachapp.co";
-        private readonly string ApiVersion = "api/v1";
+        private readonly string ApiVersion = "api/v2";
 
         private static int recordTypePersonId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_PERSON.AsGuid() ).Id;
         private static int recordStatusPendingId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_PENDING.AsGuid() ).Id;

--- a/rocks.kfs.Reach/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.Reach/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2024 by Kingdom First Solutions
+// Copyright 2026 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.Reach" )]
 [assembly: AssemblyProduct( "rocks.kfs.Reach" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2024" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2026" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "2.4.*" )]
+[assembly: AssemblyVersion( "2.5.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Reach is phasing out v1 of their API. v2 is pretty much the same just with more fields and capabilities. Updated the version and it started working again for Kensington.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Updated Reach API download to v2

---------

### Requested By

##### Who reported, requested, or paid for the change?

KCC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

rocks.kfs.Reach/Gateway.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
