### PR TITLE
Better Cybersource error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository and the surrounding Rock checkout.
+
+## Repository layout
+
+This folder (`KFSRockAssemblies`) lives inside a full Rock RMS source tree (e.g. `C:\KFSRepo\Rock\Rock16`, `C:\KFSRepo\Rock\Rock17`, etc). Most of that tree is **upstream Rock core code that we do not control** — avoid editing it. The KFS-owned code is junction-linked into the Rock tree (see `CreateLinks.bat`) and lives in:
+
+| Path (relative to Rock root) | What it is |
+|---|---|
+| `KFSRockAssemblies\` | This repo — KFS Rock assemblies/plugins (class libraries, jobs, workflow actions, financial gateways, integrations) |
+| `RockWeb\Plugins\rocks_kfs\` | KFS RockBlocks repo — WebForms blocks (.ascx) |
+| `RockAttendedCheckin\` | KFS Attended Check-in |
+| `RockWeb\Plugins\cc_newspring\` | Attended Check-in blocks (linked from RockAttendedCheckin) |
+| `com.protectmyministry.RockPlugin\` and `RockWeb\Plugins\com.protectmyministry\` | Protect My Ministry background check plugin |
+| `RockWeb\Content\KFSRockAssets\` | KFS shared assets |
+
+## Rules of thumb
+
+- **Default to working inside the KFS-owned paths above.** Treat any edit to core Rock files (`Rock\`, `Rock.*\`, `RockWeb\` outside the plugin folders, etc.) as a core patch that is not allowed.
+- Each `rocks.kfs.*` folder is its own project/plugin. Follow the conventions of the specific project you're editing (namespaces `rocks.kfs.*`, Apache 2.0 license headers on source files).
+- Blocks (UI) generally live in the RockBlocks repo (`RockWeb\Plugins\rocks_kfs`); supporting assemblies, jobs, models, and migrations live here in RockAssemblies. A feature often spans both.
+
+## Solution / build
+
+- `KFSRock.sln.kfs` in this folder is the master solution. It is copied out to the Rock root (e.g. as `KFSRock16.sln`) and used from there so relative project references resolve against the Rock tree.
+- This `CLAUDE.md` is copied to the Rock root at the same time (see the root `CreateLinks.bat`) so Claude Code sessions started at the Rock root always load it. Edit the copy in `KFSRockAssemblies` — the root copy is generated.
+- Projects target .NET Framework (Rock v16-era). Build with Visual Studio/MSBuild against the copied solution at the Rock root, not from inside this folder.
+- Plugin assemblies reference Rock core assemblies by relative path — the sibling folder structure described in `README.md` must be intact for builds to work.

--- a/CreateLinks.bat
+++ b/CreateLinks.bat
@@ -1,5 +1,11 @@
+del .\KFSRockAssemblies
+del .\RockAttendedCheckin
+del .\RockWeb\Plugins\rocks_kfs
+del .\RockWeb\Plugins\cc_newspring 
+del .\RockWeb\Content\KFSRockAssets
 mklink /J KFSRockAssemblies c:\KFSRepo\Rock\KFSRockAssemblies
 mklink /J RockAttendedCheckin c:\KFSRepo\Rock\RockAttendedCheckin 
 mklink /J RockWeb\Plugins\rocks_kfs c:\KFSRepo\Rock\KFSRockBlocks
 mklink /J RockWeb\Plugins\cc_newspring c:\KFSRepo\Rock\RockAttendedCheckin\cc_newspring
 mklink /J RockWeb\Content\KFSRockAssets c:\KFSRepo\Rock\KFSRockAssets
+copy /Y KFSRockAssemblies\CLAUDE.md CLAUDE.md

--- a/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
+++ b/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
@@ -215,10 +215,29 @@ namespace rocks.kfs.CyberSource.Controls
 
         microform.createToken(options, function (err, token) {{
             if (err) {{
-                // handle error
                 console.error(err);
-                $errorsOutput.text(err.message)
+
+                var errorMessage = err.message;
+                if (err.details && err.details.length > 0) {{
+                    var fieldLabels = {{ number: 'Card Number', securityCode: 'Security Code', expirationMonth: 'Expiration Month', expirationYear: 'Expiration Year' }};
+                    errorMessage = err.details.map(function (detail) {{
+                        return (fieldLabels[detail.location] || detail.location) + ' is invalid or missing.';
+                    }}).join(' ');
+                }}
+
+                $errorsOutput.text(errorMessage);
                 $errorsOutput.parent().show();
+
+                // reset any 'Processing...' loading buttons back to their original state so the user can
+                // correct the fields and try again. Don't post back here: the partial postback re-render
+                // would tear down the microform iframes and lose the entered values.
+                $('.btn-give-now, .js-submit-hostedpaymentinfo, .navigation.actions .btn').each(function () {{
+                    var $btn = $(this);
+                    if ($btn.attr('data-init-text')) {{
+                        $btn.html($btn.attr('data-init-text'));
+                    }}
+                    $btn.prop('disabled', false).removeAttr('disabled').removeClass('disabled');
+                }});
             }} else {{
                 flexResponse.val(token);
 
@@ -345,8 +364,10 @@ namespace rocks.kfs.CyberSource.Controls
 
             if ( _hfPaymentInfoToken.Value.IsNullOrWhiteSpace() )
             {
+                // _divValidationMessage is a div, so its client-set text does not round-trip on postback;
+                // use a fixed message for the unexpected case of a token postback without a token
                 hostedGatewayPaymentControlTokenEventArgs.IsValid = false;
-                hostedGatewayPaymentControlTokenEventArgs.ErrorMessage = _divValidationMessage.InnerText;
+                hostedGatewayPaymentControlTokenEventArgs.ErrorMessage = "Invalid or missing payment information. Please check your card number, expiration date, and security code.";
             }
             else
             {

--- a/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
+++ b/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
@@ -164,55 +164,57 @@ namespace rocks.kfs.CyberSource.Controls
     function initCyberSourceMicroFormFields() {{
         if ($('.cybersource-payment-inputs .js-credit-card-input').length == 0) {{
             // control hasn't been rendered so skip
-            if (number != undefined) {{ try {{ number.unload(); }} catch (e) {{ }} number = undefined; }}
-            if (securityCode != undefined) {{ try {{ securityCode.unload(); }} catch (e) {{ }} securityCode = undefined; }}
+            if (number != undefined && securityCode != undefined) {{
+                number.unload();
+                securityCode.unload();
+            }}
             return;
         }}
+        if (number == undefined && securityCode == undefined) {{
+            number = microform.createField('number', {{ placeholder: '0000 0000 0000 0000' }});
+            securityCode = microform.createField('securityCode');
 
-        if (number != undefined || securityCode != undefined) {{
-            if ($('.cybersource-payment-inputs .js-credit-card-input iframe').length > 0) {{
-                // the existing fields are still attached to the DOM (a partial postback that did not
-                // re-render the payment inputs); leave them and any entered values alone
-                checkCybersourceFieldsLoaded(false);
-                return;
-            }}
+            // attach handlers once, when the fields are created. The field objects survive the
+            // unload/load cycle below, so re-attaching on every init would stack duplicates.
+            number.on('error', function(data) {{
+                var $errorsOutput = $('.js-validation-message');
 
-            // a postback re-rendered the containers and destroyed the field iframes. A microform
-            // field can only be loaded once, so start over with a fresh microform instance and new
-            // fields instead of re-loading the stale ones (which throws and leaves dead inputs).
-            try {{ number.unload(); }} catch (e) {{ }}
-            try {{ securityCode.unload(); }} catch (e) {{ }}
-            microform = flex.microform({{ styles: myStyles }});
-            number = undefined;
-            securityCode = undefined;
+                console.error(data);
+                $errorsOutput.text(data.message);
+                $errorsOutput.parent().show();
+            }});
+
+            number.on('change', function(data) {{
+              // look these up at event time: a postback replaces these elements while the field
+              // object (and this handler) live on, so references captured at init would go stale.
+              var cardIcon = document.querySelector('#cardDisplay');
+              var cardSecurityCodeLabel = document.querySelector('label.credit-card-cvv-label');
+              if (data.card.length === 1) {{
+                if (cardIcon) {{ cardIcon.className = 'fa-2x ' + cardIcons[data.card[0].name]; }}
+                if (cardSecurityCodeLabel) {{ cardSecurityCodeLabel.textContent = data.card[0].securityCode.name; }}
+              }} else if (cardIcon) {{
+                cardIcon.className = 'fa-2x fas fa-credit-card';
+              }}
+            }});
         }}
-
-        number = microform.createField('number', {{ placeholder: '0000 0000 0000 0000' }});
-        securityCode = microform.createField('securityCode');
 
         number.load('.cybersource-payment-inputs .js-credit-card-input');
         securityCode.load('.cybersource-payment-inputs .js-credit-card-cvv-input');
 
-        number.on('error', function(data) {{
-            var $errorsOutput = $('.js-validation-message');
-
-            console.error(data);
-            $errorsOutput.text(data.message);
-            $errorsOutput.parent().show();
-        }});
-
-        number.on('change', function(data) {{
-          var cardIcon = document.querySelector('#cardDisplay');
-          var cardSecurityCodeLabel = document.querySelector('label.credit-card-cvv-label');
-          if (data.card.length === 1) {{
-            if (cardIcon) {{ cardIcon.className = 'fa-2x ' + cardIcons[data.card[0].name]; }}
-            if (cardSecurityCodeLabel) {{ cardSecurityCodeLabel.textContent = data.card[0].securityCode.name; }}
-          }} else if (cardIcon) {{
-            cardIcon.className = 'fa-2x fas fa-credit-card';
-          }}
-        }});
-
         checkCybersourceFieldsLoaded(false);
+    }}
+
+    // Resets any 'Processing...' loading buttons back to their original state so the user can
+    // correct the fields and try again. Does not post back: a partial postback re-render would
+    // tear down the microform iframes and lose the entered values.
+    function resetCyberSourceLoadingButtons() {{
+        $('.btn-give-now, .js-submit-hostedpaymentinfo, .navigation.actions .btn').each(function () {{
+            var $btn = $(this);
+            if ($btn.attr('data-init-text')) {{
+                $btn.html($btn.attr('data-init-text'));
+            }}
+            $btn.prop('disabled', false).removeAttr('disabled').removeClass('disabled');
+        }});
     }}
 
     function submitCyberSourceMicroFormInfo() {{
@@ -221,6 +223,26 @@ namespace rocks.kfs.CyberSource.Controls
         var expMonth = $('.cybersource-payment-inputs .js-monthyear-month');
         var expYear = $('.cybersource-payment-inputs .js-monthyear-year');
         var $errorsOutput = $('.js-validation-message');
+
+        // The Expiration Month/Year come from a Rock MonthYearPicker, not the microform iframes, so
+        // CyberSource does not validate them - createToken will happily tokenize with a missing year
+        // and the bad expiration is only caught later when the charge is attempted. Validate here so
+        // the user cannot advance past this step (and consume the capture context) without them.
+        var expMonthVal = parseInt(expMonth.val(), 10);
+        var expYearVal = parseInt(expYear.val(), 10);
+        var expErrors = [];
+        if (!expMonthVal) {{
+            expErrors.push('Expiration Month');
+        }}
+        if (!expYearVal) {{
+            expErrors.push('Expiration Year');
+        }}
+        if (expErrors.length > 0) {{
+            $errorsOutput.text(expErrors.join(' and ') + (expErrors.length === 1 ? ' is required.' : ' are required.'));
+            $errorsOutput.parent().show();
+            resetCyberSourceLoadingButtons();
+            return;
+        }}
 
         var options = {{
             expirationMonth: ('00'+expMonth.val()).slice(-2),
@@ -242,16 +264,7 @@ namespace rocks.kfs.CyberSource.Controls
                 $errorsOutput.text(errorMessage);
                 $errorsOutput.parent().show();
 
-                // reset any 'Processing...' loading buttons back to their original state so the user can
-                // correct the fields and try again. Don't post back here: the partial postback re-render
-                // would tear down the microform iframes and lose the entered values.
-                $('.btn-give-now, .js-submit-hostedpaymentinfo, .navigation.actions .btn').each(function () {{
-                    var $btn = $(this);
-                    if ($btn.attr('data-init-text')) {{
-                        $btn.html($btn.attr('data-init-text'));
-                    }}
-                    $btn.prop('disabled', false).removeAttr('disabled').removeClass('disabled');
-                }});
+                resetCyberSourceLoadingButtons();
             }} else {{
                 flexResponse.val(token);
 

--- a/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
+++ b/rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
@@ -164,16 +164,31 @@ namespace rocks.kfs.CyberSource.Controls
     function initCyberSourceMicroFormFields() {{
         if ($('.cybersource-payment-inputs .js-credit-card-input').length == 0) {{
             // control hasn't been rendered so skip
-            if (number != undefined && securityCode != undefined) {{
-                number.unload();
-                securityCode.unload();
-            }}
+            if (number != undefined) {{ try {{ number.unload(); }} catch (e) {{ }} number = undefined; }}
+            if (securityCode != undefined) {{ try {{ securityCode.unload(); }} catch (e) {{ }} securityCode = undefined; }}
             return;
         }}
-        if (number == undefined && securityCode == undefined) {{
-            number = microform.createField('number', {{ placeholder: '0000 0000 0000 0000' }});
-            securityCode = microform.createField('securityCode');
+
+        if (number != undefined || securityCode != undefined) {{
+            if ($('.cybersource-payment-inputs .js-credit-card-input iframe').length > 0) {{
+                // the existing fields are still attached to the DOM (a partial postback that did not
+                // re-render the payment inputs); leave them and any entered values alone
+                checkCybersourceFieldsLoaded(false);
+                return;
+            }}
+
+            // a postback re-rendered the containers and destroyed the field iframes. A microform
+            // field can only be loaded once, so start over with a fresh microform instance and new
+            // fields instead of re-loading the stale ones (which throws and leaves dead inputs).
+            try {{ number.unload(); }} catch (e) {{ }}
+            try {{ securityCode.unload(); }} catch (e) {{ }}
+            microform = flex.microform({{ styles: myStyles }});
+            number = undefined;
+            securityCode = undefined;
         }}
+
+        number = microform.createField('number', {{ placeholder: '0000 0000 0000 0000' }});
+        securityCode = microform.createField('securityCode');
 
         number.load('.cybersource-payment-inputs .js-credit-card-input');
         securityCode.load('.cybersource-payment-inputs .js-credit-card-cvv-input');
@@ -186,14 +201,13 @@ namespace rocks.kfs.CyberSource.Controls
             $errorsOutput.parent().show();
         }});
 
-        var cardIcon = document.querySelector('#cardDisplay');
-        var cardSecurityCodeLabel = document.querySelector('label.credit-card-cvv-label');
-
         number.on('change', function(data) {{
+          var cardIcon = document.querySelector('#cardDisplay');
+          var cardSecurityCodeLabel = document.querySelector('label.credit-card-cvv-label');
           if (data.card.length === 1) {{
-            cardIcon.className = 'fa-2x ' + cardIcons[data.card[0].name];
-            cardSecurityCodeLabel.textContent = data.card[0].securityCode.name;
-          }} else {{
+            if (cardIcon) {{ cardIcon.className = 'fa-2x ' + cardIcons[data.card[0].name]; }}
+            if (cardSecurityCodeLabel) {{ cardSecurityCodeLabel.textContent = data.card[0].securityCode.name; }}
+          }} else if (cardIcon) {{
             cardIcon.className = 'fa-2x fas fa-credit-card';
           }}
         }});
@@ -316,7 +330,14 @@ namespace rocks.kfs.CyberSource.Controls
         {
             base.OnLoad( e );
 
-            if ( !Page.IsPostBack )
+            var scriptManager = ScriptManager.GetCurrent( this.Page );
+            var isInAsyncPostBack = scriptManager != null && scriptManager.IsInAsyncPostBack;
+
+            // Register on the initial load and on full postbacks: a full postback (e.g. a failed
+            // validator elsewhere on the block) rebuilds the whole page without this script block,
+            // leaving initCyberSourceMicroFormFields undefined and the card fields dead. Skip async
+            // postbacks so partial updates keep the existing microform instance and entered values.
+            if ( !isInAsyncPostBack )
             {
                 ScriptManager.RegisterClientScriptBlock( this, this.GetType(), "microformJSBlock", string.Format( MicroformJS, microformJWK, this.ClientID, _hfPaymentInfoToken.ClientID ), true );
             }

--- a/rocks.kfs.CyberSource/Gateway.cs
+++ b/rocks.kfs.CyberSource/Gateway.cs
@@ -395,14 +395,32 @@ namespace rocks.kfs.CyberSource
                 transaction.ForeignKey = chargeResult.TokenInformation?.Customer?.Id;
             }
 
+            // The Transaction Details API is a search index that is only eventually consistent, so a
+            // payment that was just created returns 404 until it has been indexed. Retry with a backoff
+            // (waiting between attempts rather than after each one) to give it time to show up.
             TssV2TransactionsGet200Response transactionDetail = null;
             var requestCount = 0;
-            while ( ( transactionDetail == null || transactionDetail.PaymentInformation == null ) && requestCount < 10 )
+            var retryDelayMilliseconds = 250;
+            while ( ( transactionDetail == null || transactionDetail.PaymentInformation == null ) && requestCount < 8 )
             {
+                if ( requestCount > 0 )
+                {
+                    Thread.Sleep( retryDelayMilliseconds );
+                    retryDelayMilliseconds = Math.Min( retryDelayMilliseconds * 2, 1500 );
+                }
+
                 transactionDetail = GetTransactionDetailResponse( financialGateway, chargeResult.Id );
                 requestCount += 1;
-                Thread.Sleep( 250 );
             }
+
+            if ( transactionDetail == null || transactionDetail.PaymentInformation == null )
+            {
+                // CreatePayment already succeeded, so the card has been charged. Keep the transaction and
+                // let the payment detail stay sparse: losing the card metadata is far better than throwing
+                // away the record of a payment the person was actually charged for.
+                ExceptionLogService.LogException( $"CyberSource payment {chargeResult.Id} was processed but the transaction detail was still unavailable after {requestCount} attempts. The transaction was saved without payment detail (card type, masked account number, expiration)." );
+            }
+
             transaction.FinancialPaymentDetail = CreatePaymentPaymentDetail( transactionDetail );
 
             transaction.AdditionalLavaFields = GetAdditionalLavaFields( chargeResult );
@@ -1659,32 +1677,55 @@ namespace rocks.kfs.CyberSource
         /// <param name="financialPaymentDetail">The financial payment detail.</param>
         private void UpdateFinancialPaymentDetail( TssV2TransactionsGet200Response transactionDetail, FinancialPaymentDetail financialPaymentDetail )
         {
-            financialPaymentDetail.GatewayPersonIdentifier = transactionDetail.PaymentInformation?.Customer?.Id;
+            var paymentInformation = transactionDetail?.PaymentInformation;
+            if ( paymentInformation == null )
+            {
+                // The transaction detail was never returned by the gateway (see Charge). The charge itself
+                // has already gone through, so leave the detail sparse instead of throwing.
+                return;
+            }
 
-            string paymentType = transactionDetail.PaymentInformation.PaymentType.Type;
+            financialPaymentDetail.GatewayPersonIdentifier = paymentInformation.Customer?.Id;
+
+            string paymentType = paymentInformation.PaymentType?.Type;
             if ( paymentType == "credit card" )
             {
                 // cc payment
                 var curType = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_CREDIT_CARD );
-                financialPaymentDetail.NameOnCard = $"{transactionDetail.OrderInformation.BillTo.FirstName} {transactionDetail.OrderInformation.BillTo.LastName}";
+                var billTo = transactionDetail.OrderInformation?.BillTo;
+                if ( billTo != null )
+                {
+                    financialPaymentDetail.NameOnCard = $"{billTo.FirstName} {billTo.LastName}";
+                }
+
                 financialPaymentDetail.CurrencyTypeValueId = curType != null ? curType.Id : ( int? ) null;
 
                 //// The gateway tells us what the CreditCardType is since it was selected using their hosted payment entry frame.
                 //// So, first see if we can determine CreditCardTypeValueId using the CardType response from the gateway
 
                 // See if we can figure it out from the CC Type (Amex, Visa, etc)
-                var creditCardTypeValue = CreditCardPaymentInfo.GetCreditCardTypeFromName( transactionDetail.ProcessingInformation.PaymentSolution );
-                if ( creditCardTypeValue == null )
+                DefinedValueCache creditCardTypeValue = null;
+                var paymentSolution = transactionDetail.ProcessingInformation?.PaymentSolution;
+                if ( paymentSolution.IsNotNullOrWhiteSpace() )
+                {
+                    creditCardTypeValue = CreditCardPaymentInfo.GetCreditCardTypeFromName( paymentSolution );
+                }
+
+                if ( creditCardTypeValue == null && paymentInformation.Card != null )
                 {
                     // GetCreditCardTypeFromName should have worked, but just in case, see if we can figure it out from the MaskedCard using RegEx
-                    creditCardTypeValue = CreditCardPaymentInfo.GetCreditCardTypeFromCreditCardNumber( transactionDetail.PaymentInformation.Card.Prefix );
+                    creditCardTypeValue = CreditCardPaymentInfo.GetCreditCardTypeFromCreditCardNumber( paymentInformation.Card.Prefix );
                 }
 
                 financialPaymentDetail.CreditCardTypeValueId = creditCardTypeValue?.Id;
-                financialPaymentDetail.AccountNumberMasked = $"{transactionDetail.PaymentInformation.Card.Prefix}XXXXXX{transactionDetail.PaymentInformation.Card.Suffix}";
 
-                financialPaymentDetail.ExpirationMonth = transactionDetail.PaymentInformation.Card.ExpirationMonth.AsIntegerOrNull();
-                financialPaymentDetail.ExpirationYear = transactionDetail.PaymentInformation.Card.ExpirationYear.AsIntegerOrNull();
+                if ( paymentInformation.Card != null )
+                {
+                    financialPaymentDetail.AccountNumberMasked = $"{paymentInformation.Card.Prefix}XXXXXX{paymentInformation.Card.Suffix}";
+
+                    financialPaymentDetail.ExpirationMonth = paymentInformation.Card.ExpirationMonth.AsIntegerOrNull();
+                    financialPaymentDetail.ExpirationYear = paymentInformation.Card.ExpirationYear.AsIntegerOrNull();
+                }
             }
             // ACH not supported by majority of CyberSource Payment Processors.
             //else

--- a/rocks.kfs.CyberSource/Properties/AssemblyInfo.cs
+++ b/rocks.kfs.CyberSource/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2025 by Kingdom First Solutions
+// Copyright 2026 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle( "rocks.kfs.CyberSource" )]
 [assembly: AssemblyProduct( "rocks.kfs.CyberSource" )]
-[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2025" )]
+[assembly: AssemblyCopyright( "Copyright © Kingdom First Solutions 2026" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.3.*" )]
+[assembly: AssemblyVersion( "1.4.*" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/rocks.kfs.JavaScript.Obsidian/package-lock.json
+++ b/rocks.kfs.JavaScript.Obsidian/package-lock.json
@@ -79,6 +79,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
       "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
@@ -3992,6 +3993,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
       "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -4346,7 +4348,8 @@
       "version": "14.18.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.26.tgz",
       "integrity": "sha512-0b+utRBSYj8L7XAp0d+DX7lI4cSmowNaaTkk6/1SKzbKkG+doLuPusB9EOvzLJ8ahJSk03bTLIL6cWaEd4dBKA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/prettier": {
       "version": "2.6.0",
@@ -4490,6 +4493,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -4642,6 +4646,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.35.tgz",
       "integrity": "sha512-2wKQtnuHfwBFc7uV2Cmtms3Cc7u/u6kKJI3F+i0A+9xnuahK39cCMNJKHzI9x93Xai+uft64fDc5JSh8zDQBQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.35",
@@ -4713,6 +4718,7 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.35.tgz",
       "integrity": "sha512-ZMF8V+bZ0EIjSB7yzPEmDlxRDOIXj04iqG4Rw/H5rIuBCf0b7rNTleiOldlX5haG++zUq6uiL2AVp/A9uyz+cw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.2.35",
         "@vue/shared": "3.2.35"
@@ -4976,6 +4982,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5168,6 +5175,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -5477,6 +5485,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -6377,6 +6386,7 @@
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -7458,6 +7468,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.4.tgz",
       "integrity": "sha512-tEFhVQFF/bzoYV1YuGyzLPZ6vlPrdfvDmmAxudA1dLEuiztqg2Rkx20vkKY32xiDROcD2KXlgZ7Cu8RPeEHRKw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.6.4",
         "@jest/types": "^29.6.3",
@@ -10880,6 +10891,7 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
@@ -11766,6 +11778,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
       "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12499,6 +12512,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12670,6 +12684,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12832,6 +12847,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.35.tgz",
       "integrity": "sha512-mc/15B0Wjd/4JMMGOcXUQAeXfjyg8MImA2EVZucNdyDPJe1nXhMNbYXOEVPEGfk/mCeyszCzl44dSAhHhQVH8g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.35",
         "@vue/compiler-sfc": "3.2.35",

--- a/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
+++ b/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
@@ -22,7 +22,12 @@
                     <div class="row">
                         <div class="col-xs-6 exp-col">
                             <div class="iframe-input credit-card-exp-input js-credit-card-exp-input"></div>
-                            <DatePartsPicker label="Expiration Date" :isRequired="true" :startYear="nowYear" :futureYearCount="15" v-model="ccexpvalue" :showBlankItem="false" :multiple="false" :hideDay="true" :disabled="isSaving" />
+                            <!-- NOTE: isRequired is not a DatePartsPicker prop, so it never registered any validation, and
+                                 rules="required" is not a drop in replacement: it auto-adds a 'datekey' rule, and with
+                                 hideDay the day stays 0, so the date key would never validate. A missing expiration is
+                                 caught by createToken instead, which rejects the 0 month/year and reports it through the
+                                 err.details handler in submitCybersourceMicroFormInfo. -->
+                            <DatePartsPicker label="Expiration Date" :startYear="nowYear" :futureYearCount="15" v-model="ccexpvalue" :showBlankItem="false" :multiple="false" :hideDay="true" :disabled="isSaving" />
                         </div>
                         <div class="col-xs-6 cvv-col">
                             <div class="form-group">

--- a/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
+++ b/rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs
@@ -113,9 +113,15 @@
         securityCode: { name:string }
     }
 
+    type MicroformValidationDetail = {
+        location: string;
+        message?: string;
+    }
+
     type MicroformResponse = {
         card: Array<MicroformCard>;
         message: string;
+        details?: Array<MicroformValidationDetail>;
     }
     type MicroformField = {
         _config: object;
@@ -463,10 +469,27 @@
 
          FlexJS?.microform?.createToken(options, function (err, token) {
              if (err) {
-                 // handle error
                  console.error(err);
                  isSaving.value = false;
-                 emit(GatewayEmitStrings.Error, err.message);
+                 FlexJS.inSubmission = false;
+
+                 // when the failure is field validation (invalid or empty inputs), emit Validation so the
+                 // block treats it as recoverable field errors rather than a gateway error
+                 if (err.details && err.details.length > 0) {
+                     const fieldLabels: Record<string, string> = {
+                         number: "Card Number",
+                         securityCode: "Security Code",
+                         expirationMonth: "Expiration Month",
+                         expirationYear: "Expiration Year"
+                     };
+                     emit(GatewayEmitStrings.Validation, err.details.map(detail => ({
+                         name: fieldLabels[detail.location] ?? detail.location,
+                         text: "is invalid or missing."
+                     })));
+                 }
+                 else {
+                     emit(GatewayEmitStrings.Error, err.message);
+                 }
              } else {
                  hasReceivedToken = true;
                  let addressToken = {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Better Cybersource error handling added as validation before would lockup the payment process.

Also snuck in a few environmental changes to support Claude in our repository.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed Cybersource error handling.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Island

---------

### Screenshots

##### Does this update or add options to the block UI?

Before it would get stuck with the next button changed to "Processing..."
After:   
<img width="886" height="631" alt="image" src="https://github.com/user-attachments/assets/b6510d53-82cb-4378-a2da-99703399a210" />

---------

### Change Log

##### What files does it affect?

- CLAUDE.md
- CreateLinks.bat
- rocks.kfs.CyberSource/Controls/CyberSourceHostedPaymentControl.cs
- rocks.kfs.CyberSource/Properties/AssemblyInfo.cs
- rocks.kfs.JavaScript.Obsidian/src/Controls/cyberSourceGatewayControl.obs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
